### PR TITLE
small improvements to error handling

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -24,6 +24,6 @@ trait GraphQLService[F[_]] {
 
   def subscribe(request: ParsedGraphQLRequest): Stream[F, Either[Throwable, Json]]
 
-  def format(err: Throwable): Json
+  def format(err: Throwable): F[Json]
 
 }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -106,7 +106,7 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
 
   def toResponse(result: Either[Throwable, Json]): F[Response[F]] =
     result match {
-      case Left(err)   => BadRequest(service.format(err))
+      case Left(err)   => Ok(service.format(err)) // in GraphQL errors are reported in a 200 Ok response (!)
       case Right(json) => Ok(json)
     }
 
@@ -120,12 +120,12 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
   ): F[Response[F]] =
     vars0.sequence.fold(
       errors =>
-        BadRequest(errors.map(_.sanitized).mkString_("", ",", "")),
+        Ok(errors.map(_.sanitized).mkString_("", ",", "")), // in GraphQL errors are reported in a 200 Ok response (!)
 
       vars   =>
         parse(query) match {
           case Left(error) =>
-            BadRequest(service.format(error))
+            Ok(service.format(error)) // in GraphQL errors are reported in a 200 Ok response (!)
 
           case Right(ast)  =>
             for {

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
@@ -68,9 +68,9 @@ object Subscriptions {
 
   // Converts raw graphQL subscription events into FromServer messages.
   private def fromServerPipe[F[_]](id: String, service: GraphQLService[F]): Pipe[F, Either[Throwable, Json], FromServer] =
-    _.map {
-      case Left(err)   => Error(id, service.format(err))
-      case Right(json) => json.toStreamingMessage(id)
+    _.flatMap {
+      case Left(err)   => Stream.eval(service.format(err)).map(Error(id, _))
+      case Right(json) => Stream(json.toStreamingMessage(id))
     }
 
   def apply[F[_]: Logger: Concurrent](

--- a/modules/sangria/src/main/scala/lucuma/graphql/routes/SangriaGraphQLService.scala
+++ b/modules/sangria/src/main/scala/lucuma/graphql/routes/SangriaGraphQLService.scala
@@ -84,7 +84,7 @@ class SangriaGraphQLService[F[_]: Async, A](
 
   }
 
-  def format(err: Throwable): Json =
-    ErrorFormatter.format(err)
+  def format(err: Throwable): F[Json] =
+    ErrorFormatter.format(err).pure[F]
 
 }


### PR DESCRIPTION
This improves error handling in a few ways:

- Back ends now format errors in `F`, which allows for logging (and potentially other effects that might be useful).
- With GraphQL over HTTP we return 200 OK even if the response includes errors (we had been returning 400 BAD REQUEST, which is incorrect).