### PR TITLE
Add op to parse(query)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.4"
+ThisBuild / tlBaseVersion := "0.5"
 
 val clueVersion                 = "0.23.1"
 val fs2Version                  = "3.2.7"

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -150,7 +150,7 @@ object Connection {
 
         val parseResult =
           service
-            .parse(raw.query)
+            .parse(raw.query, raw.operationName)
             .map(ParsedGraphQLRequest(_, raw.operationName, raw.variables))
 
         val action = parseResult match {

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -16,7 +16,7 @@ trait GraphQLService[F[_]] {
     vars:  Option[Json]
   )
 
-  def parse(query: String): Either[Throwable, Document]
+  def parse(query: String, op: Option[String]): Either[Throwable, Document]
 
   def isSubscription(doc: ParsedGraphQLRequest): Boolean
 

--- a/modules/grackle/src/main/scala/lucuma/graphql/routes/GrackleGraphQLService.scala
+++ b/modules/grackle/src/main/scala/lucuma/graphql/routes/GrackleGraphQLService.scala
@@ -34,8 +34,8 @@ class GrackleGraphQLService[F[_]: MonadThrow: Logger: Trace](
       case _                         => false
     }
 
-  def parse(query: String): Either[Throwable, Document] =
-    QueryParser.parseText(query).toEither.leftMap(GrackleException(_))
+  def parse(query: String, op: Option[String]): Either[Throwable, Document] =
+    QueryParser.parseText(query, op).toEither.leftMap(GrackleException(_))
 
   def query(request: ParsedGraphQLRequest): F[Either[Throwable, Json]] =
     Trace[F].span("graphql") {

--- a/modules/sangria/src/main/scala-2/lucuma/graphql/routes/SangriaGraphQLService.scala
+++ b/modules/sangria/src/main/scala-2/lucuma/graphql/routes/SangriaGraphQLService.scala
@@ -30,7 +30,7 @@ class SangriaGraphQLService[F[_]: Async, A](
 
   type Document = sangria.ast.Document
 
-  def parse(query: String): Either[Throwable, Document] =
+  def parse(query: String, op: Option[String]): Either[Throwable, Document] =
     QueryParser.parse(query).toEither
 
   def isSubscription(req: ParsedGraphQLRequest): Boolean =


### PR DESCRIPTION
The `GrackleGraphQLService` implements `def parse(query: String) ...` by calling Grackle's `QueryParser.parseText(query)`.  Unfortunately `parseText` will fail if there are multiple named queries but no operation name is provided.  Note that `Sangria` does not need the operation name to parse the query.

I wonder if it is correct for Grackle to require the operation name here, since presumably it could parse all the operations and return a map of operation name to `UntypedOperation` (or something).  Assuming it is correct though, we need to thread the operation name through to it which is what is done in this PR.