### PR TITLE
Update playground to use GraphiQL

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Playground.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Playground.scala
@@ -9,65 +9,84 @@ object Playground {
     graphQLPath: String,
     wsPath:      String,
   ): String =
+    // https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html
     s"""|<!DOCTYPE html>
-        |<html>
-        |
-        |<head>
-        |  <meta charset=utf-8/>
-        |  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-        |  <title>GraphQL Playground</title>
-        |  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-        |  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-        |  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
-        |</head>
-        |
-        |<body>
-        |  <div id="root">
+        |<html lang="en">
+        |  <head>
+        |    <meta charset="UTF-8" />
+        |    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        |    <title>GraphQL Playground</title>
         |    <style>
         |      body {
-        |        background-color: rgb(23, 42, 58);
-        |        font-family: Open Sans, sans-serif;
-        |        height: 90vh;
-        |      }
-        |
-        |      #root {
         |        height: 100%;
+        |        margin: 0;
         |        width: 100%;
-        |        display: flex;
-        |        align-items: center;
-        |        justify-content: center;
+        |        overflow: hidden;
         |      }
         |
-        |      .loading {
-        |        font-size: 32px;
-        |        font-weight: 200;
-        |        color: rgba(255, 255, 255, .6);
-        |        margin-left: 20px;
-        |      }
-        |
-        |      img {
-        |        width: 78px;
-        |        height: 78px;
-        |      }
-        |
-        |      .title {
-        |        font-weight: 400;
+        |      #graphiql {
+        |        height: 100vh;
         |      }
         |    </style>
-        |    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
-        |    <div class="loading"> Loading
-        |      <span class="title">GraphQL Playground</span>
-        |    </div>
-        |  </div>
-        |  <script>window.addEventListener('load', function (event) {
-        |      GraphQLPlayground.init(document.getElementById('root'), {
-        |        // options as 'endpoint' belong here
-        |        'endpoint': '/$graphQLPath',
-        |        'subscriptionEndpoint': '/$wsPath'
-        |      })
-        |    })</script>
-        |</body>
+        |    <!--
+        |           This GraphiQL example depends on Promise and fetch, which are available in
+        |           modern browsers, but can be "polyfilled" for older browsers.
+        |           GraphiQL itself depends on React DOM.
+        |           If you do not want to rely on a CDN, you can host these files locally or
+        |           include them directly in your favored resource bundler.
+        |         -->
+        |    <script
+        |      crossorigin
+        |      src="https://unpkg.com/react@18/umd/react.development.js"
+        |    ></script>
+        |    <script
+        |      crossorigin
+        |      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+        |    ></script>
+        |    <!--
+        |           These two files can be found in the npm module, however you may wish to
+        |           copy them directly into your environment, or perhaps include them in your
+        |           favored resource bundler.
+        |          -->
+        |    <script
+        |      src="https://unpkg.com/graphiql/graphiql.min.js"
+        |      type="application/javascript"
+        |    ></script>
+        |    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+        |    <!-- 
+        |           These are imports for the GraphIQL Explorer plugin.
+        |          -->
+        |    <script
+        |      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
+        |      crossorigin
+        |    ></script>
         |
+        |    <link
+        |      rel="stylesheet"
+        |      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+        |    />
+        |  </head>
+        |  <body>
+        |    <div id="graphiql">Loading...</div>
+        |    <noscript>You need to enable JavaScript to run the playground.</noscript>
+        |    <script>
+        |      const root = ReactDOM.createRoot(document.getElementById("graphiql"));
+        |      const fetcher = GraphiQL.createFetcher({
+        |        url: "/$graphQLPath",
+        |        subscriptionUrl: "/$wsPath",
+        |      });
+        |      const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
+        |      root.render(
+        |        React.createElement(GraphiQL, {
+        |          fetcher,
+        |          defaultEditorToolsVisibility: true,
+        |          plugins: [explorerPlugin],
+        |          defaultHeaders: '{ Authorization: "Bearer yourTokenHere" }',
+        |          shouldPersistHeaders: true,
+        |        })
+        |      );
+        |    </script>
+        |  </body>
         |</html>
         |""".stripMargin
 


### PR DESCRIPTION
The "Apollo Server Playground" we used is end-of-life since 31 December 2022 and will no longer receive updates of any kind. [See here](https://www.apollographql.com/docs/apollo-server/v2/testing/graphql-playground/).

This PR updates the playground to use the new ["GraphiQL" playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme). Which should have all the same functionality without any of the security issues.
