### PR TITLE
Grackle 0.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-ThisBuild / tlBaseVersion := "0.7"
+ThisBuild / tlBaseVersion := "0.8"
 
-val clueVersion                   = "0.32.0"
+val clueVersion                = "0.32.0"
 val fs2Version                 = "3.2.7"
-val grackleVersion             = "0.14.0"
+val grackleVersion             = "0.15.0"
 val http4sVersion              = "0.23.23"
 val kindProjectorVersion       = "0.13.2"
 val log4catsVersion            = "2.6.0"
@@ -28,20 +28,20 @@ lazy val core = project
     name := "lucuma-graphql-routes",
     libraryDependencies ++= Seq(
       "edu.gemini"     %% "clue-model"             % clueVersion,
-      "edu.gemini"     %% "gsp-graphql-core"       % grackleVersion,
       "org.http4s"     %% "http4s-circe"           % http4sVersion,
       "org.http4s"     %% "http4s-dsl"             % http4sVersion,
       "org.http4s"     %% "http4s-server"          % http4sVersion,
       "org.tpolecat"   %% "natchez-core"           % natchezVersion,
+      "org.typelevel"  %% "grackle-core"           % grackleVersion,
       "org.typelevel"  %% "log4cats-core"          % log4catsVersion,
-      "edu.gemini"     %% "gsp-graphql-circe"      % grackleVersion             % Test,
-      "edu.gemini"     %% "clue-http4s"            % clueVersion                % Test,
-      "org.scalameta"  %% "munit"                  % munitVersion               % Test,
-      "org.typelevel"  %% "munit-cats-effect-3"    % munitCatsEffectVersion     % Test,
-      "org.http4s"     %% "http4s-jdk-http-client" % http4sJdkHttpClientVersion % Test,
-      "org.http4s"     %% "http4s-blaze-server"    % http4sBlazeVersion         % Test,
-      "org.typelevel"  %% "log4cats-slf4j"         % log4catsVersion            % Test,
       "ch.qos.logback" %  "logback-classic"        % logbackVersion             % Test,
-        "io.circe"       %% "circe-literal"                   % circeVersion % Test,
+      "edu.gemini"     %% "clue-http4s"            % clueVersion                % Test,
+      "io.circe"       %% "circe-literal"          % circeVersion               % Test,
+      "org.http4s"     %% "http4s-blaze-server"    % http4sBlazeVersion         % Test,
+      "org.http4s"     %% "http4s-jdk-http-client" % http4sJdkHttpClientVersion % Test,
+      "org.scalameta"  %% "munit"                  % munitVersion               % Test,
+      "org.typelevel"  %% "grackle-circe"          % grackleVersion             % Test,
+      "org.typelevel"  %% "log4cats-slf4j"         % log4catsVersion            % Test,
+      "org.typelevel"  %% "munit-cats-effect-3"    % munitCatsEffectVersion     % Test,
     ),
   )

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -15,8 +15,8 @@ import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.FromClient._
 import clue.model.StreamingMessage.FromServer._
 import clue.model.StreamingMessage._
-import edu.gemini.grackle.Operation
-import edu.gemini.grackle.Result._
+import grackle.Operation
+import grackle.Result._
 import io.circe.Json
 import io.circe.JsonObject
 import lucuma.graphql.routes.mkGraphqlError

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -6,13 +6,12 @@ package lucuma.graphql.routes
 import cats.MonadThrow
 import cats.data.NonEmptyChain
 import cats.syntax.all._
-import edu.gemini.grackle
-import edu.gemini.grackle.Mapping
-import edu.gemini.grackle.Operation
-import edu.gemini.grackle.Problem
-import edu.gemini.grackle.Result
 import fs2.Compiler
 import fs2.Stream
+import grackle.Mapping
+import grackle.Operation
+import grackle.Problem
+import grackle.Result
 import io.circe.Json
 import io.circe.JsonObject
 import natchez.Trace

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -11,8 +11,8 @@ import cats.implicits._
 import clue.model.StreamingMessage.FromClient
 import clue.model.StreamingMessage.FromServer
 import clue.model.json._
-import edu.gemini.grackle.Result
 import fs2.Stream
+import grackle.Result
 import io.circe._
 import io.circe.syntax._
 import org.http4s.Header

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
@@ -11,10 +11,10 @@ import cats.effect.syntax.all._
 import cats.implicits._
 import clue.model.StreamingMessage.FromServer._
 import clue.model.StreamingMessage._
-import edu.gemini.grackle.Result
 import fs2.Pipe
 import fs2.Stream
 import fs2.concurrent.SignallingRef
+import grackle.Result
 import io.circe.Json
 import org.typelevel.log4cats.Logger
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
@@ -10,9 +10,9 @@ import cats.syntax.all._
 import clue.model.GraphQLError
 import clue.model.StreamingMessage.FromServer
 import clue.model.*
-import edu.gemini.grackle.Problem
-import edu.gemini.grackle.Result
-import edu.gemini.grackle.Result.*
+import grackle.Problem
+import grackle.Result
+import grackle.Result.*
 import io.circe.Json
 
 package object routes {

--- a/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
@@ -6,10 +6,10 @@ package lucuma.graphql.routes
 import cats.effect.*
 import cats.implicits.*
 import clue.DisconnectedException
-import edu.gemini.grackle.Result
-import edu.gemini.grackle.circe.CirceMapping
-import edu.gemini.grackle.syntax.*
 import fs2.Stream
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
 import io.circe.Json
 import io.circe.literal.*
 import natchez.Trace.Implicits.noop

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ValidationSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ValidationSuite.scala
@@ -6,8 +6,8 @@ package lucuma.graphql.routes
 import cats.effect.*
 import cats.implicits.*
 import clue.ResponseException
-import edu.gemini.grackle.circe.CirceMapping
-import edu.gemini.grackle.syntax.*
+import grackle.circe.CirceMapping
+import grackle.syntax.*
 import io.circe.Json
 import io.circe.literal.*
 import natchez.Trace.Implicits.noop

--- a/modules/core/src/test/scala/lucuma/graphql/routes/VariablesSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/VariablesSuite.scala
@@ -5,15 +5,15 @@ package lucuma.graphql.routes
 
 import cats.effect.*
 import cats.implicits.*
-import edu.gemini.grackle.Query.Binding
-import edu.gemini.grackle.QueryCompiler.Elab
-import edu.gemini.grackle.QueryCompiler.SelectElaborator
-import edu.gemini.grackle.Result
-import edu.gemini.grackle.Schema
-import edu.gemini.grackle.Value.StringValue
-import edu.gemini.grackle.circe.CirceMapping
-import edu.gemini.grackle.syntax.*
 import fs2.Stream
+import grackle.Query.Binding
+import grackle.QueryCompiler.Elab
+import grackle.QueryCompiler.SelectElaborator
+import grackle.Result
+import grackle.Schema
+import grackle.Value.StringValue
+import grackle.circe.CirceMapping
+import grackle.syntax.*
 import io.circe.Json
 import io.circe.literal.*
 import natchez.Trace.Implicits.noop


### PR DESCRIPTION
This updates to grackle 0.15, which is identical to 0.14 but with Typelevel coordinates and without `edu.gemini`.