### PR TITLE
Workaround false 'unused' warning.

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -23,8 +23,11 @@ class GraphQLService[F[_]: MonadThrow: Trace](
   def isSubscription(op: Operation): Boolean =
     mapping.schema.subscriptionType.exists(_ =:= op.rootTpe)
 
+  // TODO: a temporary workaround for a bug in 0.18.1 which is fixed in
+  // https://github.com/typelevel/grackle/pull/566.
+  // Once there is a 0.18.2 or better, we can remove `reportUnused = false`.
   def parse(query: String, op: Option[String], vars: Option[JsonObject]): Result[Operation] =
-    mapping.compiler.compile(query, op, vars.map(_.toJson))
+    mapping.compiler.compile(query, op, vars.map(_.toJson), reportUnused = false)
 
   def query(op: Operation): F[Result[Json]] =
     Trace[F].span("graphql") {


### PR DESCRIPTION
There is an issue in Grackle which causes fragments contained in other fragments to be reported as "unused" in a validation step.  This [has been fixed](https://github.com/typelevel/grackle/pull/566) but not released.  To make progress while waiting for a release, this PR offers the workaround of ignoring this validation check.