### PR TITLE
don't crash ws connection when there's an internal error

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -155,7 +155,7 @@ object Connection {
           case Success(op)        => if (service.isSubscription(op)) subscribe(id, op) else execute(id, op)
           case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op) else execute(id, op) // n.b. warnings on subscribe are lost
           case Failure(ps)        => send(Error(id, ps.toNonEmptyList.map(mkGraphqlError)).some)
-          case InternalError(err) => err.raiseError[F, Unit]
+          case InternalError(err) => send(Error(id, mkGraphqlErrors(err)).some)
         }
         (this, action)
       }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
@@ -29,12 +29,15 @@ package object routes {
   def mkGraphqlErrors(problems: NonEmptyChain[Problem]): GraphQLErrors =
     problems.toNonEmptyList.map(mkGraphqlError)
 
+  def mkGraphqlErrors(error: Throwable): GraphQLErrors =
+    NonEmptyList.one(mkGraphqlError(Problem(s"Internal Error: ${error.getMessage}")))
+
   def mkFromServer[F[_]: MonadThrow](r: Result[Json], id: String): F[Either[FromServer.Error, FromServer.Data]] =
     r match {
       case Success(json)      => FromServer.Data(id, GraphQLResponse(json.rightIor)).asRight.pure[F]
       case Warning(ps, json)  => FromServer.Data(id, GraphQLResponse(Ior.both(mkGraphqlErrors(ps), json))).asRight.pure[F]
       case Failure(ps)        => FromServer.Error(id, mkGraphqlErrors(ps)).asLeft.pure[F]
-      case InternalError(err) => MonadThrow[F].raiseError(err)
+      case InternalError(err) => FromServer.Error(id, mkGraphqlErrors(err)).asLeft.pure[F]
     }
 
 }


### PR DESCRIPTION
The previous behavior here is that the websocket handler would crash and disconnect if a GraphQLService result indicated an internal error, but this isn't really what we want. This changes the handling to return a WebSocket error message in that case instead.