### PR TITLE
Fix initialization error message

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val clueVersion                = "0.37.0"
+val clueVersion                = "0.38.1"
 val fs2Version                 = "3.2.7"
 val grackleVersion             = "0.20.0"
 val http4sVersion              = "0.23.27"

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -15,10 +15,12 @@ import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.*
 import clue.model.StreamingMessage.FromClient.*
 import clue.model.StreamingMessage.FromServer.*
+import clue.model.json.*
 import grackle.Operation
 import grackle.Result.*
 import io.circe.Json
 import io.circe.JsonObject
+import io.circe.syntax.*
 import lucuma.graphql.routes.mkGraphqlError
 import org.http4s.ParseResult
 import org.http4s.headers.Authorization
@@ -259,7 +261,7 @@ object Connection {
 
               // User has insufficient privileges to connect.
               case None =>
-                reply(Some(FromServer.Error("<none>", NonEmptyList.one(GraphQLError("Not authorized."))))) *>
+                reply(Some(FromServer.ConnectionError(GraphQLError("Not authorized.").asJsonObject))) *>
                 handle(_.close)
 
             }

--- a/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
@@ -5,7 +5,7 @@ package lucuma.graphql.routes
 
 import cats.effect.*
 import cats.implicits.*
-import clue.DisconnectedException
+import clue.RemoteInitializationException
 import fs2.Stream
 import grackle.Result
 import grackle.circe.CirceMapping
@@ -75,20 +75,20 @@ class AuthSuite extends BaseSuite:
   test("[http] Correct credentials should work."):
     testQuery(Some("bob"), Http)
 
-  test("[ws, one-off] Missing credentials should raise DisconnectedException."):
-    interceptIO[DisconnectedException](testQuery(None, Ws))
+  test("[ws, one-off] Missing credentials should raise RemoteInitializationException."):
+    interceptIO[RemoteInitializationException](testQuery(None, Ws))
 
-  test("[ws, one-off] Incorrect credentials should raise DisconnectedException."):
-    interceptIO[DisconnectedException](testQuery(Some("steve"), Ws))
+  test("[ws, one-off] Incorrect credentials should raise RemoteInitializationException."):
+    interceptIO[RemoteInitializationException](testQuery(Some("steve"), Ws))
 
   test("[ws, one-off] Correct credentials should work."):
     testQuery(Some("bob"), Ws)
   
-  test("[ws, subscription] Missing credentials should raise DisconnectedException."):
-    interceptIO[DisconnectedException](testSubscription(None))
+  test("[ws, subscription] Missing credentials should raise RemoteInitializationException."):
+    interceptIO[RemoteInitializationException](testSubscription(None))
 
-  test("[ws, subscription] Incorrect credentials should raise DisconnectedException."):
-    interceptIO[DisconnectedException](testSubscription(Some("steve")))
+  test("[ws, subscription] Incorrect credentials should raise RemoteInitializationException."):
+    interceptIO[RemoteInitializationException](testSubscription(Some("steve")))
 
   test("[ws, subscription] Correct credentials should work."):
     testSubscription(Some("bob"))


### PR DESCRIPTION
According to [the protocol we are following](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init), a rejected initialization should be answered with a `ConnectionError`.

Also, `clue` now has a specific exception for this case.