### PR TITLE
Replace GraphQL Playground with GraphiQL Explorer

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Playground.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Playground.scala
@@ -7,68 +7,98 @@ object Playground {
 
   def apply(
     graphQLPath: String,
-    wsPath:      String,
+    wsPath:      String
   ): String =
+    // https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn
     s"""|<!DOCTYPE html>
-        |<html>
-        |
-        |<head>
-        |  <meta charset=utf-8/>
-        |  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-        |  <title>GraphQL Playground</title>
-        |  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-        |  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-        |  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
-        |</head>
-        |
-        |<body>
-        |  <div id="root">
+        |<html lang="en">
+        |  <head>
+        |    <meta charset="UTF-8" />
+        |    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        |    <title>GraphiQL Explorer</title>
         |    <style>
         |      body {
-        |        background-color: rgb(23, 42, 58);
-        |        font-family: Open Sans, sans-serif;
-        |        height: 90vh;
+        |        margin: 0;
         |      }
         |
-        |      #root {
-        |        height: 100%;
-        |        width: 100%;
-        |        display: flex;
-        |        align-items: center;
-        |        justify-content: center;
+        |      #graphiql {
+        |        height: 100dvh;
         |      }
         |
         |      .loading {
-        |        font-size: 32px;
-        |        font-weight: 200;
-        |        color: rgba(255, 255, 255, .6);
-        |        margin-left: 20px;
-        |      }
-        |
-        |      img {
-        |        width: 78px;
-        |        height: 78px;
-        |      }
-        |
-        |      .title {
-        |        font-weight: 400;
+        |        font-family: sans-serif;
+        |        height: 100%;
+        |        display: flex;
+        |        align-items: center;
+        |        justify-content: center;
+        |        font-size: 4rem;
         |      }
         |    </style>
-        |    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
-        |    <div class="loading"> Loading
-        |      <span class="title">GraphQL Playground</span>
-        |    </div>
-        |  </div>
-        |  <script>window.addEventListener('load', function (event) {
-        |      GraphQLPlayground.init(document.getElementById('root'), {
-        |        // options as 'endpoint' belong here
-        |        'endpoint': '$graphQLPath',
-        |        'subscriptionEndpoint': '$wsPath',
-                 'schema.polling.enable': false
-        |      })
-        |    })</script>
-        |</body>
+        |    <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
+        |    <link
+        |      rel="stylesheet"
+        |      href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css"
+        |    />
+        |    <!-- 
+        |    Note:
+        |    The ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file.
+        |    `@emotion/is-prop-valid` is a shim to remove the console error ` module "@emotion /is-prop-valid" not found`. Upstream issue: https://github.com/motiondivision/motion/issues/3126 -->
+        |    <script type="importmap">
+        |      {
+        |        "imports": {
+        |          "react": "https://esm.sh/react@19.1.1",
+        |          "react/": "https://esm.sh/react@19.1.1/",
         |
+        |          "react-dom": "https://esm.sh/react-dom@19.1.1",
+        |          "react-dom/": "https://esm.sh/react-dom@19.1.1/",
+        |
+        |          "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+        |          "graphiql/": "https://esm.sh/graphiql/",
+        |          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+        |          "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid",
+        |
+        |          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+        |          "graphql": "https://esm.sh/graphql@16.11.0",
+        |          "subscriptions-transport-ws": "https://esm.sh/subscriptions-transport-ws@0.11.0",
+        |
+        |          "@emotion/is-prop-valid": "data:text/javascript,"
+        |        }
+        |      }
+        |    </script>
+        |    <script type="module">
+        |      import React from 'react';
+        |      import ReactDOM from 'react-dom/client';
+        |      import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
+        |      import { createGraphiQLFetcher } from '@graphiql/toolkit';
+        |      import { explorerPlugin } from '@graphiql/plugin-explorer';
+        |      import { SubscriptionClient } from 'subscriptions-transport-ws';
+        |      import 'graphiql/setup-workers/esm.sh';
+        |
+        |      const fetcher = createGraphiQLFetcher({
+        |        url: '$graphQLPath',
+        |        legacyWsClient: new SubscriptionClient('$wsPath'),
+        |      });
+        |      const plugins = [HISTORY_PLUGIN, explorerPlugin()];
+        |
+        |      function App() {
+        |        return React.createElement(GraphiQL, {
+        |          fetcher,
+        |          plugins,
+        |          defaultEditorToolsVisibility: true,
+        |          shouldPersistHeaders: true,
+        |        });
+        |      }
+        |
+        |      const container = document.getElementById('graphiql');
+        |      const root = ReactDOM.createRoot(container);
+        |      root.render(React.createElement(App));
+        |    </script>
+        |  </head>
+        |  <body>
+        |    <div id="graphiql">
+        |      <div class="loading">Loading...</div>
+        |    </div>
+        |  </body>
         |</html>
         |""".stripMargin
 


### PR DESCRIPTION
The Playground has been deprecated for a while, and GraphiQL is the recommended replacement.

Works with queries and subscriptions. Tested on ODB and navigate-server.
