### PR TITLE
Improve otel traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ The resulting `HttpRoutes` will serve the following endpoints:
 - `Root / "playground.html"` serving the [GraphQL Playground](https://github.com/graphql/graphql-playground) HTML application.
 
 The `"graphql"`, `"ws"`, and `"playground.html"` segments are defaults; you can specify different values when you call `Routes.forService`.
+
+## Tracing
+
+This library uses [otel4s](https://typelevel.org/otel4s/) for OpenTelemetry tracing. A `Tracer[F]` must be in scope when constructing routes. Each operation produces a `graphql` span with `graphql.document`, `graphql.operation.type`, and `graphql.operation.name` semconv attributes.
+
+Trace context propagation differs by transport:
+
+- **HTTP (queries/mutations)**: The standard `traceparent` HTTP header is propagated automatically by the http4s otel4s middleware in the calling application.
+- **WebSocket subscriptions**: The WebSocket endpoint uses the [graphql-transport-ws](https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md) protocol. If the client includes a W3C `traceparent` in the `extensions` field of the `subscribe` message, this library extracts it and re-parents the server span on the client's remote trace context, enabling end-to-end distributed tracing per subscription operation.

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val otel4sVersion              = "0.16.0"
 enablePlugins(NoPublishPlugin)
 
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.3.3")
-ThisBuild / tlBaseVersion := "0.12"
-ThisBuild / scalaVersion       := "3.8.3"
-ThisBuild / crossScalaVersions := Seq("3.8.3")
+ThisBuild / tlBaseVersion       := "0.12"
+ThisBuild / scalaVersion        := "3.8.3"
+ThisBuild / crossScalaVersions  := Seq("3.8.3")
 
 // Tests work fine in parallel but the output get interleaved, which can be confusing.
 // It's fast so there's no harm doing them sequentially here.
@@ -27,21 +27,22 @@ lazy val core = project
   .settings(
     name := "lucuma-graphql-routes",
     libraryDependencies ++= Seq(
-      "edu.gemini"     %% "clue-model"             % clueVersion,
-      "org.http4s"     %% "http4s-circe"           % http4sVersion,
-      "org.http4s"     %% "http4s-dsl"             % http4sVersion,
-      "org.http4s"     %% "http4s-server"          % http4sVersion,
-      "org.typelevel"  %% "otel4s-core-trace"      % otel4sVersion,
-      "org.typelevel"  %% "grackle-core"           % grackleVersion,
-      "org.typelevel"  %% "log4cats-core"          % log4catsVersion,
-      "ch.qos.logback" %  "logback-classic"        % logbackVersion             % Test,
-      "edu.gemini"     %% "clue-http4s"            % clueVersion                % Test,
-      "io.circe"       %% "circe-literal"          % circeVersion               % Test,
-      "org.http4s"     %% "http4s-blaze-server"    % http4sBlazeVersion         % Test,
-      "org.http4s"     %% "http4s-jdk-http-client" % http4sJdkHttpClientVersion % Test,
-      "org.scalameta"  %% "munit"                  % munitVersion               % Test,
-      "org.typelevel"  %% "grackle-circe"          % grackleVersion             % Test,
-      "org.typelevel"  %% "log4cats-slf4j"         % log4catsVersion            % Test,
-      "org.typelevel"  %% "munit-cats-effect"      % munitCatsEffectVersion     % Test,
+      "edu.gemini"     %% "clue-model"                  % clueVersion,
+      "org.http4s"     %% "http4s-circe"                % http4sVersion,
+      "org.http4s"     %% "http4s-dsl"                  % http4sVersion,
+      "org.http4s"     %% "http4s-server"               % http4sVersion,
+      "org.typelevel"  %% "otel4s-core-trace"           % otel4sVersion,
+      "org.typelevel"  %% "otel4s-semconv-experimental" % otel4sVersion,
+      "org.typelevel"  %% "grackle-core"                % grackleVersion,
+      "org.typelevel"  %% "log4cats-core"               % log4catsVersion,
+      "ch.qos.logback" %  "logback-classic"             % logbackVersion             % Test,
+      "edu.gemini"     %% "clue-http4s"                 % clueVersion                % Test,
+      "io.circe"       %% "circe-literal"               % circeVersion               % Test,
+      "org.http4s"     %% "http4s-blaze-server"         % http4sBlazeVersion         % Test,
+      "org.http4s"     %% "http4s-jdk-http-client"      % http4sJdkHttpClientVersion % Test,
+      "org.scalameta"  %% "munit"                       % munitVersion               % Test,
+      "org.typelevel"  %% "grackle-circe"               % grackleVersion             % Test,
+      "org.typelevel"  %% "log4cats-slf4j"              % log4catsVersion            % Test,
+      "org.typelevel"  %% "munit-cats-effect"           % munitCatsEffectVersion     % Test,
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val otel4sVersion              = "0.16.0"
 enablePlugins(NoPublishPlugin)
 
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.3.3")
-ThisBuild / tlBaseVersion       := "0.12"
+ThisBuild / tlBaseVersion       := "0.13"
 ThisBuild / scalaVersion        := "3.8.3"
 ThisBuild / crossScalaVersions  := Seq("3.8.3")
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -161,8 +161,9 @@ object Connection {
         extensions:    Option[GraphQLExtensions],
         operationName: Option[String]
       ): F[Unit] =
-        T.span("connection.subscribe", Attribute("connection.fromclient.id", id)).use:
-          _.addAttributes(service.props*) >>
+        T.withCurrentSpanOrNoop: span =>
+          span.addAttributes(Attribute("connection.fromclient.id", id)) >>
+            span.addAttributes(service.props*) >>
             subscriptions.add(id, service.subscribe(request, document, extensions, operationName))
 
       def execute(
@@ -172,8 +173,9 @@ object Connection {
         extensions:    Option[GraphQLExtensions],
         operationName: Option[String]
       ): F[Unit] =
-        T.span("connection.execute", Attribute("connection.fromclient.id", id)).use:
-          _.addAttributes(service.props*) >>
+        T.withCurrentSpanOrNoop: span =>
+          span.addAttributes(Attribute("connection.fromclient.id", id)) >>
+            span.addAttributes(service.props*) >>
             service.query(request, document, extensions, operationName).flatMap { r =>
               mkFromServer(r, id).flatMap {
                 case Right(data) => send(data.asRight.some) *> send(FromServer.Complete(id).asRight.some)

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -138,11 +138,13 @@ object Connection {
         )
 
       override def start(id: String, raw: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) = {
-        val parseResult = service.parse(raw.query.value, raw.operationName, raw.variables)
+        val document    = raw.query.value
+        val parseResult = service.parse(document, raw.operationName, raw.variables)
         val ext         = raw.extensions
+        val name        = raw.operationName
         val action = parseResult match {
-          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, ext) else execute(id, op, ext)
-          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, ext) else execute(id, op, ext) // n.b. warnings on subscribe are lost
+          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, document, ext, name) else execute(id, op, document, ext, name)
+          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, document, ext, name) else execute(id, op, document, ext, name) // n.b. warnings on subscribe are lost
           case Failure(ps)        => send(Error(id, ps.toNonEmptyList.map(mkGraphqlError)).asRight.some)
           case InternalError(err) => send(Error(id, mkGraphqlErrors(err)).asRight.some)
         }
@@ -152,15 +154,27 @@ object Connection {
       override def stop(id: String): (ConnectionState[F], F[Unit]) =
         (this, subscriptions.remove(id))
 
-      def subscribe(id: String, request: Operation, extensions: Option[GraphQLExtensions]): F[Unit] =
+      def subscribe(
+        id:            String,
+        request:       Operation,
+        document:      String,
+        extensions:    Option[GraphQLExtensions],
+        operationName: Option[String]
+      ): F[Unit] =
         T.span("connection.subscribe", Attribute("connection.fromclient.id", id)).use:
           _.addAttributes(service.props*) >>
-            subscriptions.add(id, service.subscribe(request, extensions))
+            subscriptions.add(id, service.subscribe(request, document, extensions, operationName))
 
-      def execute(id: String, request: Operation, extensions: Option[GraphQLExtensions]): F[Unit] =
+      def execute(
+        id:            String,
+        request:       Operation,
+        document:      String,
+        extensions:    Option[GraphQLExtensions],
+        operationName: Option[String]
+      ): F[Unit] =
         T.span("connection.execute", Attribute("connection.fromclient.id", id)).use:
           _.addAttributes(service.props*) >>
-            service.query(request, extensions).flatMap { r =>
+            service.query(request, document, extensions, operationName).flatMap { r =>
               mkFromServer(r, id).flatMap {
                 case Right(data) => send(data.asRight.some) *> send(FromServer.Complete(id).asRight.some)
                 case Left(error) => send(error.asRight.some)

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -9,6 +9,7 @@ import cats.effect.Concurrent
 import cats.effect.Ref
 import cats.effect.std.Queue
 import cats.syntax.all.*
+import clue.model.GraphQLExtensions
 import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.*
 import clue.model.StreamingMessage.FromClient.*
@@ -138,9 +139,10 @@ object Connection {
 
       override def start(id: String, raw: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) = {
         val parseResult = service.parse(raw.query.value, raw.operationName, raw.variables)
+        val ext         = raw.extensions
         val action = parseResult match {
-          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op) else execute(id, op)
-          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op) else execute(id, op) // n.b. warnings on subscribe are lost
+          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, ext) else execute(id, op, ext)
+          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, ext) else execute(id, op, ext) // n.b. warnings on subscribe are lost
           case Failure(ps)        => send(Error(id, ps.toNonEmptyList.map(mkGraphqlError)).asRight.some)
           case InternalError(err) => send(Error(id, mkGraphqlErrors(err)).asRight.some)
         }
@@ -150,15 +152,15 @@ object Connection {
       override def stop(id: String): (ConnectionState[F], F[Unit]) =
         (this, subscriptions.remove(id))
 
-      def subscribe(id: String, request: Operation): F[Unit] =
+      def subscribe(id: String, request: Operation, extensions: Option[GraphQLExtensions]): F[Unit] =
         T.span("connection.subscribe", Attribute("connection.fromclient.id", id)).use:
           _.addAttributes(service.props*) >>
-            subscriptions.add(id, service.subscribe(request))
+            subscriptions.add(id, service.subscribe(request, extensions))
 
-      def execute(id: String, request: Operation): F[Unit] =
+      def execute(id: String, request: Operation, extensions: Option[GraphQLExtensions]): F[Unit] =
         T.span("connection.execute", Attribute("connection.fromclient.id", id)).use:
           _.addAttributes(service.props*) >>
-            service.query(request).flatMap { r =>
+            service.query(request, extensions).flatMap { r =>
               mkFromServer(r, id).flatMap {
                 case Right(data) => send(data.asRight.some) *> send(FromServer.Complete(id).asRight.some)
                 case Left(error) => send(error.asRight.some)

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -9,7 +9,6 @@ import cats.effect.Concurrent
 import cats.effect.Ref
 import cats.effect.std.Queue
 import cats.syntax.all.*
-import clue.model.GraphQLExtensions
 import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.*
 import clue.model.StreamingMessage.FromClient.*
@@ -140,15 +139,16 @@ object Connection {
       override def start(id: String, raw: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) = {
         val document    = raw.query.value
         val parseResult = service.parse(document, raw.operationName, raw.variables)
-        val ext         = raw.extensions
         val name        = raw.operationName
         val action = parseResult match {
-          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, document, ext, name) else execute(id, op, document, ext, name)
-          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, document, ext, name) else execute(id, op, document, ext, name) // n.b. warnings on subscribe are lost
+          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, document, name) else execute(id, op, document, name)
+          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, document, name) else execute(id, op, document, name) // n.b. warnings on subscribe are lost
           case Failure(ps)        => send(Error(id, ps.toNonEmptyList.map(mkGraphqlError)).asRight.some)
           case InternalError(err) => send(Error(id, mkGraphqlErrors(err)).asRight.some)
         }
-        (this, action)
+        // Re-parent server spans on the client's remote context
+        // This is valid if the client span has a W3C traceparent value in extensions)
+        (this, joinRemote(raw.extensions.traceCarrier)(action))
       }
 
       override def stop(id: String): (ConnectionState[F], F[Unit]) =
@@ -158,25 +158,23 @@ object Connection {
         id:            String,
         request:       Operation,
         document:      String,
-        extensions:    Option[GraphQLExtensions],
         operationName: Option[String]
       ): F[Unit] =
         T.withCurrentSpanOrNoop: span =>
           span.addAttributes(Attribute("connection.fromclient.id", id)) >>
             span.addAttributes(service.props*) >>
-            subscriptions.add(id, service.subscribe(request, document, extensions, operationName))
+            subscriptions.add(id, service.subscribe(request, document, operationName))
 
       def execute(
         id:            String,
         request:       Operation,
         document:      String,
-        extensions:    Option[GraphQLExtensions],
         operationName: Option[String]
       ): F[Unit] =
         T.withCurrentSpanOrNoop: span =>
           span.addAttributes(Attribute("connection.fromclient.id", id)) >>
             span.addAttributes(service.props*) >>
-            service.query(request, document, extensions, operationName).flatMap { r =>
+            service.query(request, document, operationName).flatMap { r =>
               mkFromServer(r, id).flatMap {
                 case Right(data) => send(data.asRight.some) *> send(FromServer.Complete(id).asRight.some)
                 case Left(error) => send(error.asRight.some)

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -6,7 +6,6 @@ package lucuma.graphql.routes
 import cats.MonadThrow
 import cats.data.NonEmptyChain
 import cats.syntax.all.*
-import clue.model.GraphQLExtensions
 import fs2.Compiler
 import fs2.Stream
 import grackle.Mapping
@@ -67,10 +66,8 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   def query(
     op:            Operation,
     document:      String,
-    extensions:    Option[GraphQLExtensions] = None,
-    operationName: Option[String]            = None
-  ): F[Result[Json]] = {
-    val _ = extensions
+    operationName: Option[String] = None
+  ): F[Result[Json]] =
     T.spanBuilder("graphql")
       .withSpanKind(SpanKind.Server) // it is assumed we run this on the serevr
       .addAttributes(graphqlAttributes(op, document, operationName))
@@ -83,20 +80,16 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
               GrackleException(Problem(s"Expected exactly one result, found ${other.length}."))
             )
         }
-  }
 
   def subscribe(
     op:            Operation,
     document:      String,
-    extensions:    Option[GraphQLExtensions] = None,
-    operationName: Option[String]            = None
-  ): Stream[F, Result[Json]] = {
-    val _ = extensions
+    operationName: Option[String] = None
+  ): Stream[F, Result[Json]] =
     // Decorate the current span with GraphQL semantic attributes.
     Stream.exec(
       T.withCurrentSpanOrNoop(_.addAttributes(graphqlAttributes(op, document, operationName)))
     ) ++ runInterpreter(op)
-  }
 
   private def runInterpreter(op: Operation): Stream[F, Result[Json]] =
     mapping.interpreter.run(op.query, op.rootTpe, grackle.Env.EmptyEnv)

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -16,6 +16,7 @@ import grackle.Result
 import io.circe.Json
 import io.circe.JsonObject
 import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Tracer
 
 /**
@@ -35,7 +36,11 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   def query(op: Operation, extensions: Option[GraphQLExtensions] = None): F[Result[Json]] = {
     val _ = extensions
     // I wonder if we should truncate the query
-    T.span("graphql", Attribute("graphql.query", op.query.render)).surround:
+    T.spanBuilder("graphql")
+      .withSpanKind(SpanKind.Server)
+      .addAttribute(Attribute("graphql.query", op.query.render))
+      .build
+      .surround:
       runInterpreter(op).compile.toList.map {
         case List(e) => e
         case other   =>

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -6,6 +6,7 @@ package lucuma.graphql.routes
 import cats.MonadThrow
 import cats.data.NonEmptyChain
 import cats.syntax.all.*
+import clue.model.GraphQLExtensions
 import fs2.Compiler
 import fs2.Stream
 import grackle.Mapping
@@ -22,8 +23,8 @@ import org.typelevel.otel4s.trace.Tracer
   */
 class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   val mapping: Mapping[F],
-  val props: Attribute[?]*
-)(using Compiler[F,F]) {
+  val props:   Attribute[?]*
+)(using Compiler[F, F]) {
 
   def isSubscription(op: Operation): Boolean =
     mapping.schema.subscriptionType.exists(_ =:= op.rootTpe)
@@ -31,15 +32,32 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   def parse(query: String, op: Option[String], vars: Option[JsonObject]): Result[Operation] =
     mapping.compiler.compile(query, op, vars.map(_.toJson), reportUnused = false)
 
-  def query(op: Operation): F[Result[Json]] =
+  def query(op: Operation, extensions: Option[GraphQLExtensions] = None): F[Result[Json]] = {
+    val _ = extensions
     // I wonder if we should truncate the query
     T.span("graphql", Attribute("graphql.query", op.query.render)).surround:
-      subscribe(op).compile.toList.map {
+      runInterpreter(op).compile.toList.map {
         case List(e) => e
-        case other   => Result.internalError(GrackleException(Problem(s"Expected exactly one result, found ${other.length}.")))
+        case other   =>
+          Result.internalError(
+            GrackleException(Problem(s"Expected exactly one result, found ${other.length}."))
+          )
       }
+  }
 
-  def subscribe(op: Operation): Stream[F, Result[Json]] =
+  def subscribe(
+    op:         Operation,
+    extensions: Option[GraphQLExtensions] = None
+  ): Stream[F, Result[Json]] = {
+    val _ = extensions
+    runInterpreter(op)
+  }
+
+  // Direct, non-virtual entry into the grackle interpreter. Both `query` and
+  // `subscribe` delegate here so that subclasses overriding only `subscribe`
+  // (e.g. to add a subscription-specific span) don't accidentally wrap one-off
+  // `query` calls as well.
+  private def runInterpreter(op: Operation): Stream[F, Result[Json]] =
     mapping.interpreter.run(op.query, op.rootTpe, grackle.Env.EmptyEnv)
 
 }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -16,6 +16,8 @@ import grackle.Result
 import io.circe.Json
 import io.circe.JsonObject
 import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.semconv.experimental.attributes.GraphqlExperimentalAttributes.*
 import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Tracer
 
@@ -30,38 +32,66 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   def isSubscription(op: Operation): Boolean =
     mapping.schema.subscriptionType.exists(_ =:= op.rootTpe)
 
+  def isMutation(op: Operation): Boolean =
+    mapping.schema.mutationType.exists(_ =:= op.rootTpe)
+
   def parse(query: String, op: Option[String], vars: Option[JsonObject]): Result[Operation] =
     mapping.compiler.compile(query, op, vars.map(_.toJson), reportUnused = false)
 
-  def query(op: Operation, extensions: Option[GraphQLExtensions] = None): F[Result[Json]] = {
+  // OTEL attributes for a GraphQL operation; see
+  // https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/
+  private def graphqlAttributes(
+    op:            Operation,
+    document:      String,
+    operationName: Option[String]
+  ): Attributes = {
+    val opType =
+      if isSubscription(op)  then GraphqlOperationTypeValue.Subscription.value
+      else if isMutation(op) then GraphqlOperationTypeValue.Mutation.value
+      else                   GraphqlOperationTypeValue.Query.value
+
+    Attributes(
+      (List(
+        Attribute(GraphqlDocument, document),
+        Attribute(GraphqlOperationType, opType),
+      ) ++ operationName.map(Attribute(GraphqlOperationName, _)) ++ props)*
+    )
+  }
+
+  def query(
+    op:            Operation,
+    document:      String,
+    extensions:    Option[GraphQLExtensions] = None,
+    operationName: Option[String]            = None
+  ): F[Result[Json]] = {
     val _ = extensions
-    // I wonder if we should truncate the query
     T.spanBuilder("graphql")
-      .withSpanKind(SpanKind.Server)
-      .addAttribute(Attribute("graphql.query", op.query.render))
+      .withSpanKind(SpanKind.Server) // it is assumed we run this on the serevr
+      .addAttributes(graphqlAttributes(op, document, operationName))
       .build
       .surround:
-      runInterpreter(op).compile.toList.map {
-        case List(e) => e
-        case other   =>
-          Result.internalError(
-            GrackleException(Problem(s"Expected exactly one result, found ${other.length}."))
-          )
-      }
+        runInterpreter(op).compile.toList.map {
+          case List(e) => e
+          case other   =>
+            Result.internalError(
+              GrackleException(Problem(s"Expected exactly one result, found ${other.length}."))
+            )
+        }
   }
 
   def subscribe(
-    op:         Operation,
-    extensions: Option[GraphQLExtensions] = None
+    op:            Operation,
+    document:      String,
+    extensions:    Option[GraphQLExtensions] = None,
+    operationName: Option[String]            = None
   ): Stream[F, Result[Json]] = {
     val _ = extensions
-    runInterpreter(op)
+    // Decorate the current span with GraphQL semantic attributes.
+    Stream.exec(
+      T.withCurrentSpanOrNoop(_.addAttributes(graphqlAttributes(op, document, operationName)))
+    ) ++ runInterpreter(op)
   }
 
-  // Direct, non-virtual entry into the grackle interpreter. Both `query` and
-  // `subscribe` delegate here so that subclasses overriding only `subscribe`
-  // (e.g. to add a subscription-specific span) don't accidentally wrap one-off
-  // `query` calls as well.
   private def runInterpreter(op: Operation): Stream[F, Result[Json]] =
     mapping.interpreter.run(op.query, op.rootTpe, grackle.Env.EmptyEnv)
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -38,6 +38,12 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   def parse(query: String, op: Option[String], vars: Option[JsonObject]): Result[Operation] =
     mapping.compiler.compile(query, op, vars.map(_.toJson), reportUnused = false)
 
+  private val MaxDocumentLength = 1024
+
+  private def truncateDocument(doc: String): String =
+    if doc.length <= MaxDocumentLength then doc
+    else s"${doc.take(MaxDocumentLength)}... (truncated at $MaxDocumentLength} of ${doc.length} chars)"
+
   // OTEL attributes for a GraphQL operation; see
   // https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/
   private def graphqlAttributes(
@@ -52,7 +58,7 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
 
     Attributes(
       (List(
-        Attribute(GraphqlDocument, document),
+        Attribute(GraphqlDocument, truncateDocument(document)),
         Attribute(GraphqlOperationType, opType),
       ) ++ operationName.map(Attribute(GraphqlOperationName, _)) ++ props)*
     )

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -124,7 +124,8 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
     vars0.sequence.fold(
       errors => Ok(errors.map(_.sanitized).mkString_("", ",", "")), // in GraphQL errors are reported in a 200 Ok response (!)
       // No extension for on offs
-      vars   => service.parse(query, op, vars).flatTraverse(service.query(_)).flatMap(toResponse)
+      vars   =>
+        service.parse(query, op, vars).flatTraverse(service.query(_, query, none, op)).flatMap(toResponse)
     )
 
   def oneOffPost(req: Request[F]): F[Response[F]] =
@@ -136,18 +137,18 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
       vars    = obj("variables").flatMap(_.asObject)
       ext     = obj("extensions").flatMap(_.asObject)
       parsed  = service.parse(query, op, vars)
-      result <- parsed.traverse(service.query(_, ext)).map(_.flatten)
+      result <- parsed.traverse(service.query(_, query, ext, op)).map(_.flatten)
       resp   <- toResponse(result)
     } yield resp
 
 }
 
-class WsRouteHandler[F[_]: Logger: Temporal: Tracer](service: Option[Authorization] => F[Option[GraphQLService[F]]]) {
+class WsRouteHandler[F[_]: {Logger as L, Temporal, Tracer as T}](service: Option[Authorization] => F[Option[GraphQLService[F]]]) {
 
   val KeepAliveDuration: FiniteDuration =
     5.seconds
 
-  def webSocketConnection(wsb: WebSocketBuilder2[F]): F[Response[F]] = Tracer[F].span("graphql.routes.webSocketConnection").surround {
+  def webSocketConnection(wsb: WebSocketBuilder2[F]): F[Response[F]] = T.span("graphql.routes.webSocketConnection").surround {
 
     val keepAliveStream: Stream[F, FromServer] =
       Stream
@@ -156,9 +157,9 @@ class WsRouteHandler[F[_]: Logger: Temporal: Tracer](service: Option[Authorizati
 
     def logFromServer(msg: Either[GraphQLWSError, FromServer]): F[Unit] =
       msg match {
-        case Left(err)                 => Logger[F].warn(s"Sending error to client: ${err.code} ${err.reason} - Closing connection")
-        case Right(FromServer.Ping(_)) => Logger[F].debug(s"Sending Ping")
-        case Right(msg)                  => Logger[F].debug(s"Sending to client: ${trimmedMessage(msg)}")
+        case Left(err)                 => L.warn(s"Sending error to client: ${err.code} ${err.reason} - Closing connection")
+        case Right(FromServer.Ping(_)) => L.debug(s"Sending Ping")
+        case Right(msg)                => L.debug(s"Sending to client: ${trimmedMessage(msg)}")
       }
 
     def logWebSocketFrame(f: WebSocketFrame): F[Unit] = {
@@ -169,8 +170,8 @@ class WsRouteHandler[F[_]: Logger: Temporal: Tracer](service: Option[Authorizati
       val RedactedAuth = """$1 <REDACTED>"""
 
       f match {
-        case Text(s, last) => Logger[F].debug(s"Received Text frame (last=$last) from client: ${AuthRegEx.replaceFirstIn(s, RedactedAuth)}")
-        case _             => Logger[F].debug(s"Received message from client: $f")
+        case Text(s, last) => L.debug(s"Received Text frame (last=$last) from client: ${AuthRegEx.replaceFirstIn(s, RedactedAuth)}")
+        case _             => L.debug(s"Received message from client: $f")
       }
     }
 
@@ -191,7 +192,7 @@ class WsRouteHandler[F[_]: Logger: Temporal: Tracer](service: Option[Authorizati
             .evalTap(logFromServer)
             .map{
               case Left(err) => Close(err.code, err.reason).orElse(Close(err.code)).toOption.get
-              case Right(m) => Text(m.asJson.spaces2)
+              case Right(m)  => Text(m.asJson.spaces2)
             },
 
           // Input from client

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -157,9 +157,9 @@ class WsRouteHandler[F[_]: {Logger as L, Temporal, Tracer as T}](service: Option
 
     def logFromServer(msg: Either[GraphQLWSError, FromServer]): F[Unit] =
       msg match {
-        case Left(err)                 => L.warn(s"Sending error to client: ${err.code} ${err.reason} - Closing connection")
-        case Right(FromServer.Ping(_)) => L.debug(s"Sending Ping")
-        case Right(msg)                => L.debug(s"Sending to client: ${trimmedMessage(msg)}")
+        case Left(err)                 => warn"Sending error to client: ${err.code} ${err.reason} - Closing connection"
+        case Right(FromServer.Ping(_)) => debug"Sending Ping"
+        case Right(msg)                => debug"Sending to client: ${trimmedMessage(msg)}"
       }
 
     def logWebSocketFrame(f: WebSocketFrame): F[Unit] = {
@@ -170,8 +170,8 @@ class WsRouteHandler[F[_]: {Logger as L, Temporal, Tracer as T}](service: Option
       val RedactedAuth = """$1 <REDACTED>"""
 
       f match {
-        case Text(s, last) => L.debug(s"Received Text frame (last=$last) from client: ${AuthRegEx.replaceFirstIn(s, RedactedAuth)}")
-        case _             => L.debug(s"Received message from client: $f")
+        case Text(s, last) => debug"Received Text frame (last=$last) from client: ${AuthRegEx.replaceFirstIn(s, RedactedAuth)}"
+        case _             => debug"Received message from client: $f"
       }
     }
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -123,7 +123,8 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
   ): F[Response[F]] =
     vars0.sequence.fold(
       errors => Ok(errors.map(_.sanitized).mkString_("", ",", "")), // in GraphQL errors are reported in a 200 Ok response (!)
-      vars   => service.parse(query, op, vars).flatTraverse(service.query).flatMap(toResponse)
+      // No extension for on offs
+      vars   => service.parse(query, op, vars).flatTraverse(service.query(_)).flatMap(toResponse)
     )
 
   def oneOffPost(req: Request[F]): F[Response[F]] =
@@ -131,10 +132,11 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
       body   <- req.as[Json]
       obj    <- body.asObject.liftTo[F](InvalidMessageBodyFailure("Invalid GraphQL query"))
       query  <- obj("query").flatMap(_.asString).liftTo[F](InvalidMessageBodyFailure("Missing query field"))
-      op     =  obj("operationName").flatMap(_.asString)
-      vars   =  obj("variables").flatMap(_.asObject)
-      parsed =  service.parse(query, op, vars)
-      result <- parsed.traverse(service.query).map(_.flatten)
+      op      = obj("operationName").flatMap(_.asString)
+      vars    = obj("variables").flatMap(_.asObject)
+      ext     = obj("extensions").flatMap(_.asObject)
+      parsed  = service.parse(query, op, vars)
+      result <- parsed.traverse(service.query(_, ext)).map(_.flatten)
       resp   <- toResponse(result)
     } yield resp
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -108,7 +108,7 @@ object Routes {
 
 }
 
-class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
+class HttpRouteHandler[F[_]: {Temporal, Tracer}](service: GraphQLService[F]) {
 
   val dsl: Http4sDsl[F] = new Http4sDsl[F]{}
   import dsl._
@@ -123,9 +123,9 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
   ): F[Response[F]] =
     vars0.sequence.fold(
       errors => Ok(errors.map(_.sanitized).mkString_("", ",", "")), // in GraphQL errors are reported in a 200 Ok response (!)
-      // No extension for on offs
+      // GET carries no extensions, so no remote trace context to join.
       vars   =>
-        service.parse(query, op, vars).flatTraverse(service.query(_, query, none, op)).flatMap(toResponse)
+        service.parse(query, op, vars).flatTraverse(service.query(_, query, op)).flatMap(toResponse)
     )
 
   def oneOffPost(req: Request[F]): F[Response[F]] =
@@ -137,7 +137,7 @@ class HttpRouteHandler[F[_]: Temporal](service: GraphQLService[F]) {
       vars    = obj("variables").flatMap(_.asObject)
       ext     = obj("extensions").flatMap(_.asObject)
       parsed  = service.parse(query, op, vars)
-      result <- parsed.traverse(service.query(_, query, ext, op)).map(_.flatten)
+      result <- parsed.traverse(p => joinRemote(ext.traceCarrier)(service.query(p, query, op))).map(_.flatten)
       resp   <- toResponse(result)
     } yield resp
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
@@ -15,8 +15,23 @@ import grackle.Problem
 import grackle.Result
 import grackle.Result.*
 import io.circe.Json
+import org.typelevel.otel4s.trace.Tracer
 
 package object routes {
+
+  // Extract W3C trace context headers (traceparent, tracestate) from the GraphQL
+  // `extensions` object so otel4s can re-parent spans on the client.
+  extension (extensions: Option[GraphQLExtensions])
+    private[routes] def traceCarrier: Map[String, String] =
+      extensions.fold(Map.empty):
+        _.toMap
+          .collect { case (k, v) if v.isString => k -> v.asString.orEmpty }
+          .filter((_, v) => v.nonEmpty)
+
+  // Only call it when we have a remote context; otherwise keep the current span context.
+  private[routes] def joinRemote[F[_]: Tracer, A](carrier: Map[String, String])(fa: F[A]): F[A] =
+    if carrier.contains("traceparent") then Tracer[F].joinOrRoot(carrier)(fa) else fa
+
 
   def mkGraphqlError(p: Problem): GraphQLError =
     GraphQLError(


### PR DESCRIPTION
Several changes, mostly at improving parent trace handling:

* Adds the ability to extract parent trace id from web socket clients passing the parent trace id on extension
* Uses semconv attributes for graphql
* Include the actual document content (up to a limit of 1024 chars) rather than Grackle's AST