### PR TITLE
Reply with a Pong when a client sends a Ping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val circeVersion               = "0.14.16"
-val clueVersion                = "0.57.0"
+val clueVersion                = "0.58.0"
 val fs2Version                 = "3.12.0"
 val grackleVersion             = "0.30.0"
 val http4sVersion              = "0.23.36"

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -95,7 +95,7 @@ object Connection {
         subs: Subscriptions[F],
       ): (ConnectionState[F], F[Unit]) =
         (connected(service, send, subs),
-         send(ConnectionAck().asRight.some) *> send(Ping().asRight.some)
+         send(ConnectionAck().asRight.some) *> send(FromServer.Ping().asRight.some)
         )
 
 
@@ -133,7 +133,7 @@ object Connection {
         (connected(service, r, s),
           subscriptions.removeAll  *>
             r(ConnectionAck().asRight.some) *>
-            r(Ping().asRight.some)
+            r(FromServer.Ping().asRight.some)
         )
 
       override def start(id: String, raw: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) = {
@@ -290,7 +290,8 @@ object Connection {
               case ConnectionInit(m)       => init(m)
               case Subscribe(id, request)  => handle(_.start(id, request))
               case FromClient.Complete(id) => handle(_.stop(id))
-              case Pong(_)                 => debug"Received Pong from client"
+              case FromClient.Ping(_)      => replyQueue.offer(FromServer.Pong().asRight.some)
+              case FromClient.Pong(_)      => debug"Received Pong from client"
             }
           }
 

--- a/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
@@ -5,6 +5,7 @@ package lucuma.graphql.routes
 
 import cats.effect.*
 import cats.implicits.*
+import clue.HttpStatusException
 import clue.RemoteInitializationException
 import fs2.Stream
 import grackle.Result
@@ -14,7 +15,6 @@ import io.circe.Json
 import io.circe.literal.*
 import org.http4s.AuthScheme
 import org.http4s.Credentials
-import org.http4s.client.UnexpectedStatus
 import org.http4s.headers.Authorization
 
 import BaseSuite.ClientOption
@@ -65,11 +65,11 @@ class AuthSuite extends BaseSuite:
       variables   = None
     )
 
-  test("[http] Missing credentials should raise UnexpectedStatus."):
-    interceptIO[UnexpectedStatus](testQuery(None, Http))
+  test("[http] Missing credentials should raise HttpStatusException."):
+    interceptIO[HttpStatusException](testQuery(None, Http)).map(e => assertEquals(e.status, 403))
 
-  test("[http] Incorrect credentials should raise UnexpectedStatus."):
-    interceptIO[UnexpectedStatus](testQuery(Some("steve"), Http))
+  test("[http] Incorrect credentials should raise HttpStatusException."):
+    interceptIO[HttpStatusException](testQuery(Some("steve"), Http)).map(e => assertEquals(e.status, 403))
 
   test("[http] Correct credentials should work."):
     testQuery(Some("bob"), Http)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
@@ -23,6 +23,8 @@ import io.circe.Json
 import io.circe.JsonObject
 import munit.CatsEffectSuite
 import munit.catseffect.IOFixture
+import org.http4s.client.Client
+import org.http4s.client.websocket.WSClient
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.headers.Authorization
 import org.http4s.jdkhttpclient.JdkHttpClient
@@ -79,30 +81,36 @@ abstract class BaseSuite extends CatsEffectSuite:
       EmberServerBuilder
         .default[IO]
         .withHttpWebSocketApp(app)
+        .withShutdownTimeout(Duration.Zero)
         .build
 
   private def fetchClient(bearerToken: Option[String])(svr: Server): Resource[IO, FetchClient[IO, Nothing]] =
-    for
-      xbe <- JdkHttpClient.simple[IO].map(Http4sHttpBackend[IO](_))
-      uri  = svr.baseUri / "graphql"
-      hs   = Headers(bearerToken.toList.map(s => Authorization(Credentials.Token(AuthScheme.Bearer, s)))*)
-      xc  <- Resource.eval(Http4sHttpClient.of[IO, Nothing](uri, headers = hs)(using Async[IO], xbe, Logger[IO]))
-    yield xc
+    val xbe = Http4sHttpBackend[IO](httpClientFixture())
+    val uri = svr.baseUri / "graphql"
+    val hs  = Headers(bearerToken.toList.map(s => Authorization(Credentials.Token(AuthScheme.Bearer, s)))*)
+    Resource.eval(Http4sHttpClient.of[IO, Nothing](uri, headers = hs)(using Async[IO], xbe, Logger[IO]))
 
   private def streamingClient(bearerToken: Option[String])(svr: Server): Resource[IO, WebSocketClient[IO, Nothing]] =
+    val sbe = Http4sWebSocketBackend[IO](wsClientFixture())
+    val uri = (svr.baseUri / "ws").copy(scheme = Some(Http4sUri.Scheme.unsafeFromString("ws")))
+    val ps  = bearerToken.fold(Map.empty)(s => Map("Authorization" -> Json.fromString(s"Bearer $s")))
     for
-      sbe <- JdkWSClient.simple[IO].map(Http4sWebSocketBackend[IO](_))
-      uri  = (svr.baseUri / "ws").copy(scheme = Some(Http4sUri.Scheme.unsafeFromString("ws")))
-      sc  <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri)(using Async[IO], Logger[IO], sbe))
-      ps   = bearerToken.fold(Map.empty)(s => Map("Authorization" -> Json.fromString(s"Bearer $s")))
-      _   <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
+      sc <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri)(using Async[IO], Logger[IO], sbe))
+      _  <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
     yield sc
 
   protected lazy val serverFixture: IOFixture[Server] =
     ResourceSuiteLocalFixture("server", server)
 
+  protected lazy val httpClientFixture: IOFixture[Client[IO]] =
+    ResourceSuiteLocalFixture("http-client", JdkHttpClient.simple[IO])
+
+  protected lazy val wsClientFixture: IOFixture[WSClient[IO]] =
+    ResourceSuiteLocalFixture("ws-client", JdkWSClient.simple[IO])
+
+  // The clients come first, so that munit closes them before it stops the server.
   override def munitFixtures =
-    List(serverFixture)
+    List(httpClientFixture, wsClientFixture, serverFixture)
 
   // Tests supply the query as a plain runtime `String`, so it skips the `gql` interpolator's
   // compile-time checks — there is nothing to check, no subqueries are spliced.
@@ -133,8 +141,7 @@ abstract class BaseSuite extends CatsEffectSuite:
     variables:   Option[JsonObject],
     client:      ClientOption
   ): IO[Json] =
-    Resource.eval(IO(serverFixture()))
-      .flatMap(connection(client, bearerToken))
+    connection(client, bearerToken)(serverFixture())
       .use: conn =>
         val req = conn.request(Operation(query))
         val op  =
@@ -149,8 +156,7 @@ abstract class BaseSuite extends CatsEffectSuite:
     onError: ResponseException[Json] => IO[Unit] = _ => IO.unit
   ): IO[List[Json]] =
     Supervisor[IO].use: sup =>
-      Resource.eval(IO(serverFixture()))
-        .flatMap(streamingClient(bearerToken))
+      streamingClient(bearerToken)(serverFixture())
         .use: conn =>
           val req = conn.subscribe(Operation(query))
           variables

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionPingSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionPingSuite.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.IO
+import cats.effect.std.Queue
+import cats.syntax.all.*
+import clue.model.StreamingMessage.FromClient
+import clue.model.StreamingMessage.FromServer
+import io.circe.Json
+import io.circe.JsonObject
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.otel4s.trace.Tracer
+
+/**
+ * The graphql-transport-ws protocol permits a `ping` message in both directions. The receiver must
+ * reply with a `pong` as soon as possible. A `ping` can arrive at any time on an open socket, so
+ * the reply does not depend on the connection state.
+ */
+final class ConnectionPingSuite extends CatsEffectSuite:
+
+  private type Reply = Option[Either[GraphQLWSError, FromServer]]
+
+  given Logger[IO] = Slf4jLogger.getLoggerFromName("lucuma-graphql-routes-test")
+  given Tracer[IO] = Tracer.noop[IO]
+
+  /** A connection whose service always refuses, so that no test needs a schema. */
+  private val connection: IO[(Connection[IO], Queue[IO, Reply])] =
+    for
+      queue <- Queue.unbounded[IO, Reply]
+      conn  <- Connection[IO](_ => IO.none, queue)
+    yield (conn, queue)
+
+  test("A Ping before ConnectionInit gets a Pong reply"):
+    connection.flatMap: (conn, queue) =>
+      conn.receive(FromClient.Ping()) *>
+        queue.take.assertEquals(FromServer.Pong().asRight.some)
+
+  test("A Ping with a payload gets a Pong reply without a payload"):
+    val payload = JsonObject("seq" -> Json.fromInt(1))
+    connection.flatMap: (conn, queue) =>
+      conn.receive(FromClient.Ping(payload.some)) *>
+        queue.take.assertEquals(FromServer.Pong().asRight.some)
+
+  test("A Ping does not close the connection"):
+    connection.flatMap: (conn, queue) =>
+      for
+        _ <- conn.receive(FromClient.Ping())
+        _ <- queue.take.assertEquals(FromServer.Pong().asRight.some)
+        _ <- conn.receive(FromClient.Ping())
+        _ <- queue.take.assertEquals(FromServer.Pong().asRight.some)
+      yield ()
+
+  test("A Pong from the client gets no reply"):
+    connection.flatMap: (conn, queue) =>
+      conn.receive(FromClient.Pong()) *> queue.tryTake.assertEquals(None)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/GetMutationSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/GetMutationSuite.scala
@@ -14,7 +14,6 @@ import io.circe.Json
 import org.http4s.*
 import org.http4s.headers.Allow
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.JdkHttpClient
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -70,13 +69,11 @@ class GetMutationSuite extends BaseSuite:
     query:         String,
     operationName: Option[String] = None
   ): IO[(Status, Option[Allow])] =
-    Resource.eval(IO(serverFixture())).flatMap { svr =>
-      JdkHttpClient.simple[IO].flatMap { client =>
-        val uri0 = (svr.baseUri / "graphql").withQueryParam("query", query)
-        val uri1 = operationName.fold(uri0)(n => uri0.withQueryParam("operationName", n))
-        client.run(Request[IO](Method.GET, uri1))
-      }
-    }.use(resp => IO.pure((resp.status, resp.headers.get[Allow])))
+    val uri0 = (serverFixture().baseUri / "graphql").withQueryParam("query", query)
+    val uri1 = operationName.fold(uri0)(n => uri0.withQueryParam("operationName", n))
+    httpClientFixture()
+      .run(Request[IO](Method.GET, uri1))
+      .use(resp => IO.pure((resp.status, resp.headers.get[Allow])))
 
   private val mutationDoc = "mutation { increment }"
   private val queryDoc    = "query { ping }"

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionOverHttpSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionOverHttpSuite.scala
@@ -16,7 +16,6 @@ import org.http4s.Request
 import org.http4s.Status
 import org.http4s.circe.*
 import org.http4s.headers.Authorization
-import org.http4s.jdkhttpclient.JdkHttpClient
 
 import scala.concurrent.duration.*
 
@@ -64,18 +63,15 @@ class SubscriptionOverHttpSuite extends BaseSuite:
 
   // Send a raw HTTP request to /graphql and return (status-code, parsed JSON body).
   private def rawRequest(query: String, method: Method): IO[(Status, Json)] =
-    JdkHttpClient.simple[IO].use { client =>
-      val svr     = serverFixture()
-      val baseUri = svr.baseUri / "graphql"
-      val req = method match {
-        case Method.POST =>
-          Request[IO](Method.POST, baseUri)
-            .withEntity(Json.obj("query" -> Json.fromString(query)))
-        case _ =>
-          Request[IO](method, baseUri.withQueryParam("query", query))
-      }
-      client.run(req).use(resp => resp.as[Json].map(body => (resp.status, body)))
+    val baseUri = serverFixture().baseUri / "graphql"
+    val req = method match {
+      case Method.POST =>
+        Request[IO](Method.POST, baseUri)
+          .withEntity(Json.obj("query" -> Json.fromString(query)))
+      case _ =>
+        Request[IO](method, baseUri.withQueryParam("query", query))
     }
+    httpClientFixture().run(req).use(resp => resp.as[Json].map(body => (resp.status, body)))
 
   // Assert that the response is 422 Unprocessable Content with a well-formed GraphQL JSON body
   // whose first error message names subscriptions as the problem.

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ValidationSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ValidationSuite.scala
@@ -9,7 +9,6 @@ import clue.ResponseException
 import grackle.circe.CirceMapping
 import grackle.syntax.*
 import io.circe.Json
-import io.circe.literal.*
 import org.http4s.headers.Authorization
 
 import BaseSuite.ClientOption
@@ -43,7 +42,7 @@ class ValidationSuite extends BaseSuite:
         bearerToken = None,
         query       = "subscription { x }",
         mutations   = Right(IO.unit),
-        expected    = List(1,2,3).map { n => json"""{ "bar": $n }""" },
+        expected    = Nil,
         variables   = None
       )
 


### PR DESCRIPTION
The graphql-transport-ws protocol requires a pong reply to each ping message. A graphql-ws client with the keepAlive option lost its connection on each ping.

Connection.receive now offers a FromServer.Pong to the reply queue when a FromClient.Ping arrives. The reply does not go through the state machine, because the protocol permits a ping at any time on an open socket.

This fix needs FromClient.Ping, is unreleased in clue
