### PR TITLE
Reject subscription operations over HTTP with 422 Unprocessable Content

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -12,6 +12,7 @@ import clue.model.StreamingMessage.FromClient
 import clue.model.StreamingMessage.FromServer
 import clue.model.json.given
 import fs2.Stream
+import grackle.Operation
 import grackle.Result
 import io.circe.*
 import io.circe.syntax.*
@@ -116,6 +117,28 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](service: GraphQLService[F]) {
   def toResponse(result: Result[Json]): F[Response[F]] =
     Ok(service.mapping.mkResponse(result))
 
+  // Returns a 422 Unprocessable Content response with a well-formed GraphQL JSON error body.
+  // Used by both HTTP handlers to reject subscription operations.
+  private def subscriptionRejection: F[Response[F]] =
+    UnprocessableContent(
+      service.mapping.mkResponse(
+        Result.failure[Json](
+          "Subscription operations are not supported over HTTP. Use the WebSocket transport."
+        )
+      )
+    )
+
+  // If the parsed operation is a subscription, return a 422 rejection immediately.
+  // Otherwise invoke `proceed`.  Both Success and Warning carry an Operation value.
+  private def rejectSubscription(
+    parsed: Result[Operation]
+  )(proceed: => F[Response[F]]): F[Response[F]] =
+    parsed match {
+      case Result.Success(op) if service.isSubscription(op)    => subscriptionRejection
+      case Result.Warning(_, op) if service.isSubscription(op) => subscriptionRejection
+      case _                                                    => proceed
+    }
+
   def oneOffGet(
     query: String,
     op:    Option[String],
@@ -124,8 +147,12 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](service: GraphQLService[F]) {
     vars0.sequence.fold(
       errors => Ok(errors.map(_.sanitized).mkString_("", ",", "")), // in GraphQL errors are reported in a 200 Ok response (!)
       // GET carries no extensions, so no remote trace context to join.
-      vars   =>
-        service.parse(query, op, vars).flatTraverse(service.query(_, query, op)).flatMap(toResponse)
+      vars => {
+        val parsed = service.parse(query, op, vars)
+        rejectSubscription(parsed) {
+          parsed.flatTraverse(service.query(_, query, op)).flatMap(toResponse)
+        }
+      }
     )
 
   def oneOffPost(req: Request[F]): F[Response[F]] =
@@ -137,8 +164,11 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](service: GraphQLService[F]) {
       vars    = obj("variables").flatMap(_.asObject)
       ext     = obj("extensions").flatMap(_.asObject)
       parsed  = service.parse(query, op, vars)
-      result <- parsed.traverse(p => joinRemote(ext.traceCarrier)(service.query(p, query, op))).map(_.flatten)
-      resp   <- toResponse(result)
+      resp   <- rejectSubscription(parsed) {
+                  parsed.traverse(p => joinRemote(ext.traceCarrier)(service.query(p, query, op)))
+                    .map(_.flatten)
+                    .flatMap(toResponse)
+                }
     } yield resp
 
 }

--- a/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
@@ -98,7 +98,7 @@ abstract class BaseSuite extends CatsEffectSuite:
       _   <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
     yield sc
 
-  private lazy val serverFixture: IOFixture[Server] =
+  protected lazy val serverFixture: IOFixture[Server] =
     ResourceSuiteLocalFixture("server", server)
 
   override def munitFixtures =

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionOverHttpSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionOverHttpSuite.scala
@@ -1,0 +1,146 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import fs2.Stream
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+import io.circe.literal.*
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Status
+import org.http4s.circe.*
+import org.http4s.headers.Authorization
+import org.http4s.jdkhttpclient.JdkHttpClient
+
+import scala.concurrent.duration.*
+
+import BaseSuite.ClientOption.*
+
+// Mapping used by SubscriptionOverHttpSuite. Provides a query, a mutation, and a subscription
+// with both a finite (3-element) stream and an infinite stream.
+object SubscriptionHttpMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query {
+      ping: String!
+    }
+    type Mutation {
+      noop: Boolean!
+    }
+    type Subscription {
+      finite: Int!
+      infinite: Int!
+    }
+  """
+
+  val QueryType        = schema.ref("Query")
+  val MutationType     = schema.ref("Mutation")
+  val SubscriptionType = schema.ref("Subscription")
+
+  val typeMappings = List(
+    ObjectMapping(QueryType, List(
+      CursorFieldJson("ping", _ => Result.success(Json.fromString("pong")), Nil)
+    )),
+    ObjectMapping(MutationType, List(
+      CursorFieldJson("noop", _ => Result.success(Json.fromBoolean(true)), Nil)
+    )),
+    ObjectMapping(SubscriptionType, List(
+      RootStream.computeJson("finite"): (_, _) =>
+        Stream.emits(List(1, 2, 3)).covary[IO].map(n => Result.success(Json.fromInt(n))),
+      RootStream.computeJson("infinite"): (_, _) =>
+        Stream.constant(Result.success(Json.fromInt(0))).covary[IO]
+    ))
+  )
+
+class SubscriptionOverHttpSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(SubscriptionHttpMapping).some.pure[IO]
+
+  // Send a raw HTTP request to /graphql and return (status-code, parsed JSON body).
+  private def rawRequest(query: String, method: Method): IO[(Status, Json)] =
+    JdkHttpClient.simple[IO].use { client =>
+      val svr     = serverFixture()
+      val baseUri = svr.baseUri / "graphql"
+      val req = method match {
+        case Method.POST =>
+          Request[IO](Method.POST, baseUri)
+            .withEntity(Json.obj("query" -> Json.fromString(query)))
+        case _ =>
+          Request[IO](method, baseUri.withQueryParam("query", query))
+      }
+      client.run(req).use(resp => resp.as[Json].map(body => (resp.status, body)))
+    }
+
+  // Assert that the response is 422 Unprocessable Content with a well-formed GraphQL JSON body
+  // whose first error message names subscriptions as the problem.
+  private def assert422SubscriptionError(status: Status, body: Json): Unit =
+    assertEquals(status.code, 422)
+    val errors = body.hcursor.downField("errors").as[List[Json]].getOrElse(Nil)
+    assert(errors.nonEmpty, s"Expected 'errors' in body, but got: ${body.spaces2}")
+    val msg = errors.head.hcursor.downField("message").as[String].getOrElse("")
+    assert(msg.toLowerCase.contains("subscription"),
+      s"Expected message to mention 'subscription', got: $msg")
+
+  test("[http, POST] subscription returns 422 with JSON errors body"):
+    rawRequest("subscription { finite }", Method.POST).map { (status, body) =>
+      assert422SubscriptionError(status, body)
+    }
+
+  test("[http, GET] subscription returns 422 with JSON errors body"):
+    rawRequest("subscription { finite }", Method.GET).map { (status, body) =>
+      assert422SubscriptionError(status, body)
+    }
+
+  // A subscription backed by an infinite stream must not hang. The 5-second timeout turns a
+  // regression (server blocks forever collecting the stream) into a fast failure.
+  test("[http, POST] subscription over infinite stream returns 422 promptly"):
+    rawRequest("subscription { infinite }", Method.POST)
+      .timeout(5.seconds)
+      .map { (status, body) =>
+        assert422SubscriptionError(status, body)
+      }
+
+  test("[http, POST] subscription over multi-element stream returns 422, not 'Expected exactly one result'"):
+    rawRequest("subscription { finite }", Method.POST).map { (status, body) =>
+      assert422SubscriptionError(status, body)
+      val msg = body.hcursor.downField("errors").downArray.downField("message").as[String].getOrElse("")
+      assert(!msg.contains("Expected exactly one result"),
+        s"Got old 'Expected exactly one result' error: $msg")
+    }
+
+  test("[http, POST] query still returns 200"):
+    expect(
+      bearerToken = none,
+      query       = "query { ping }",
+      expected    = Right(json"""{ "ping": "pong" }"""),
+      variables   = none,
+      client      = Http
+    )
+
+  test("[http, POST] mutation still returns 200"):
+    expect(
+      bearerToken = none,
+      query       = "mutation { noop }",
+      expected    = Right(json"""{ "noop": true }"""),
+      variables   = none,
+      client      = Http
+    )
+
+  test("[ws, subscription] subscription over WebSocket still works"):
+    subscriptionExpect(
+      bearerToken = none,
+      query       = "subscription { finite }",
+      mutations   = Right(IO.unit),
+      expected    = List(
+        json"""{ "finite": 1 }""",
+        json"""{ "finite": 2 }""",
+        json"""{ "finite": 3 }"""
+      ),
+      variables   = none
+    )


### PR DESCRIPTION
Both HTTP handlers (GET and POST) now detect subscription operations before executing them and return a 422 response with a well-formed GraphQL JSON error body.

This prevents infinite streams from hanging the request and removes the misleading "Expected exactly one result" message for multi-element streams.

The [GraphQL over HTTP spec](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md) specifies that subscription operations are beyond the scope of the spec.
