### PR TITLE
Send Complete to client when subscription stream ends

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+val catsEffectVersion          = "3.7.0"
 val circeVersion               = "0.14.16"
 val clueVersion                = "0.58.0"
 val fs2Version                 = "3.12.0"
@@ -40,6 +41,7 @@ lazy val core = project
       "org.http4s"    %% "http4s-ember-server"         % http4sVersion              % Test,
       "org.http4s"    %% "http4s-jdk-http-client"      % http4sJdkHttpClientVersion % Test,
       "org.scalameta" %% "munit"                       % munitVersion               % Test,
+      "org.typelevel" %% "cats-effect-testkit"         % catsEffectVersion          % Test,
       "org.typelevel" %% "grackle-circe"               % grackleVersion             % Test,
       "org.typelevel" %% "log4cats-slf4j"              % log4catsVersion            % Test,
       "org.typelevel" %% "munit-cats-effect"           % munitCatsEffectVersion     % Test

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
@@ -5,7 +5,9 @@ package lucuma.graphql.routes
 
 import cats.Monad
 import cats.effect.Concurrent
+import cats.effect.Deferred
 import cats.effect.Fiber
+import cats.effect.Outcome
 import cats.effect.Ref
 import cats.effect.syntax.all.*
 import cats.implicits.*
@@ -43,28 +45,23 @@ object Subscriptions {
 
   /**
    * Tracks a single client subscription.
-   * @param id      Client-supplied identification for the subscription.
    * @param results Underlying stream of results, each of which is an Either error or subscription
    *  query match
+   * @param stopped Set to true to interrupt the stream. Also identifies the subscription.
    */
   private final class Subscription[F[_]: Monad](
-    val id:      String,
-    val results: Fiber[F, Throwable, Unit],
+    val results: Deferred[F, Fiber[F, Throwable, Unit]],
     val stopped: SignallingRef[F, Boolean]
   ) {
-
-    val isStopped: F[Boolean] =
-      stopped.get
 
     val stop: F[Unit] =
       for {
         _ <- stopped.set(true)
-        _ <- results.cancel
+        f <- results.get
+        _ <- f.cancel
       } yield ()
 
   }
-
-    
 
   def apply[F[_]: Logger: Concurrent](
     send: Option[FromServer] => F[Unit]
@@ -73,34 +70,56 @@ object Subscriptions {
     Ref[F].of(Map.empty[String, Subscription[F]]).map { subscriptions =>
       new Subscriptions[F]() {
 
-        def fromServerPipe(id: String): Pipe[F, Result[Json], FromServer] =
-          _.evalMap(mkFromServer(_, id).map(_.merge))
+        // The caller that takes an entry out of the map owns the `Complete` for that id.
+        def stopAndComplete(id: String, s: Subscription[F]): F[Unit] =
+          s.stop *> send(Some(Complete(id)))
 
-        def replySink(id: String): Pipe[F, Result[Json], Unit] =
-          events => fromServerPipe(id)(events).evalMap(m => send(Some(m)))
+        // `errorSent` records that an `error` message went to the client for this id. The
+        // protocol makes `error` a terminal message, so no `complete` can follow it.
+        def replySink(id: String, errorSent: Ref[F, Boolean]): Pipe[F, Result[Json], Unit] =
+          _.evalMap { r =>
+            for {
+              e <- mkFromServer(r, id)
+              _ <- errorSent.set(true).whenA(e.isLeft)
+              _ <- send(Some(e.merge))
+            } yield ()
+          }
 
         override def add(id: String, events: Stream[F, Result[Json]]): F[Unit] =
-          for {
-            r <- SignallingRef(false)
-            in = r.discrete.evalTap(v => Logger[F].debug(s"signalling ref = $v"))
-            es = events.through(replySink(id)).interruptWhen(in)
-            _ <- Logger[F].debug(s"starting event stream $id")
-            f <- es.compile.drain.start
-            _ <- Logger[F].debug(s"started event stream $id")
-            _ <- subscriptions.update(_.updated(id, new Subscription(id, f, r)))
-          } yield ()
+          (for {
+            r         <- SignallingRef(false)
+            errorSent <- Ref[F].of(false)
+            in         = r.discrete.evalTap(v => Logger[F].debug(s"signalling ref = $v"))
+            removeOwn  = subscriptions.modify: m =>
+                            if (m.get(id).exists(_.stopped eq r)) (m.removed(id), true)
+                            else (m, false)
+            complete   = for
+                           own <- removeOwn
+                           err <- errorSent.get
+                           _   <- send(Complete(id).some).whenA(own && !err)
+                         yield ()
+            es         = events.through(replySink(id, errorSent)).interruptWhen(in)
+            fiber     <- Deferred[F, Fiber[F, Throwable, Unit]]
+            _         <- subscriptions.update(_.updated(id, new Subscription(fiber, r)))
+            _         <- Logger[F].debug(s"starting event stream $id")
+            f         <- es.compile.drain
+                           .guaranteeCase:
+                             case Outcome.Succeeded(_) => complete
+                             case _                    => removeOwn.void
+                           .start
+            _         <- fiber.complete(f)
+            _         <- Logger[F].debug(s"started event stream $id")
+          } yield ()).uncancelable // cancellation before fiber.complete would block every stop
 
         override def remove(id: String): F[Unit] =
-          for {
-            m <- subscriptions.getAndUpdate(_.removed(id))
-            _ <- m.get(id).fold(().pure[F])(s => s.stop *> send(Some(Complete(s.id))))
-          } yield ()
+          subscriptions
+            .getAndUpdate(_.removed(id))
+            .flatMap(_.get(id).traverse_(stopAndComplete(id, _)))
 
         override def removeAll: F[Unit] =
-          for {
-            m <- subscriptions.getAndSet(Map.empty[String, Subscription[F]])
-            _ <- m.values.toList.traverse_(s => s.stop *> send(Some(Complete(s.id))))
-          } yield ()
+          subscriptions
+            .getAndSet(Map.empty[String, Subscription[F]])
+            .flatMap(_.toList.traverse_((id, s) => stopAndComplete(id, s)))
 
       }
     }

--- a/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
@@ -17,6 +17,7 @@ import clue.http4s.Http4sHttpClient
 import clue.http4s.Http4sWebSocketBackend
 import clue.http4s.Http4sWebSocketClient
 import clue.websocket.WebSocketClient
+import fs2.Stream
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.Json
@@ -55,6 +56,8 @@ object BaseSuite:
     case e: ResponseException[Any]  @unchecked => ()
     case e => print("OdbSuite.reportFailure: "); e.printStackTrace
 
+  val logger: Logger[IO] = Slf4jLogger.getLoggerFromName("lucuma-odb-test")
+
   // a runtime that is constructed the same as global, but lets us see unhandled errors (above)
   val runtime: IORuntime =
     val (compute, _, _) = IORuntime.createWorkStealingComputeThreadPool(reportFailure = reportFailure)
@@ -70,7 +73,7 @@ abstract class BaseSuite extends CatsEffectSuite:
 
   override lazy val munitIoRuntime: IORuntime = BaseSuite.runtime
 
-  given Logger[IO] = Slf4jLogger.getLoggerFromName("lucuma-odb-test")
+  given Logger[IO] = BaseSuite.logger
   given Tracer[IO] = Tracer.noop[IO]
 
   private def httpApp: Resource[IO, WebSocketBuilder2[IO] => HttpApp[IO]] =
@@ -90,7 +93,7 @@ abstract class BaseSuite extends CatsEffectSuite:
     val hs  = Headers(bearerToken.toList.map(s => Authorization(Credentials.Token(AuthScheme.Bearer, s)))*)
     Resource.eval(Http4sHttpClient.of[IO, Nothing](uri, headers = hs)(using Async[IO], xbe, Logger[IO]))
 
-  private def streamingClient(bearerToken: Option[String])(svr: Server): Resource[IO, WebSocketClient[IO, Nothing]] =
+  protected def streamingClient(bearerToken: Option[String])(svr: Server): Resource[IO, WebSocketClient[IO, Nothing]] =
     val sbe = Http4sWebSocketBackend[IO](wsClientFixture())
     val uri = (svr.baseUri / "ws").copy(scheme = Some(Http4sUri.Scheme.unsafeFromString("ws")))
     val ps  = bearerToken.fold(Map.empty)(s => Map("Authorization" -> Json.fromString(s"Bearer $s")))
@@ -122,7 +125,7 @@ abstract class BaseSuite extends CatsEffectSuite:
 
   // Tests supply the query as a plain runtime `String`, so it skips the `gql` interpolator's
   // compile-time checks — there is nothing to check, no subqueries are spliced.
-  private case class Operation(query: String) extends GraphQLOperation.Typed[Nothing, JsonObject, Json]:
+  protected case class Operation(query: String) extends GraphQLOperation.Typed[Nothing, JsonObject, Json]:
     override val document = GraphQLDocument.unsafeFromString(query)
 
   def connection(cop: ClientOption, bearerToken: Option[String]): Server => Resource[IO, FetchClient[IO, Nothing]] =
@@ -156,6 +159,31 @@ abstract class BaseSuite extends CatsEffectSuite:
             variables.fold(req.apply)(req.withInput).raiseGraphQLErrors
         op
 
+  // Allocates a subscription on an open connection. Returns the result stream and the
+  // client-side cleanup action, which sends `complete` from client to server, separately.
+  protected def allocateSubscription(
+    conn:      WebSocketClient[IO, Nothing],
+    query:     String,
+    variables: Option[JsonObject],
+    onError:   ResponseException[Json] => IO[Unit] = _ => IO.unit
+  ): IO[(Stream[IO, Json], IO[Unit])] =
+    val req = conn.subscribe(Operation(query))
+    variables
+      .fold(req.apply)(req.withInput)
+      .raiseFirstNoDataError
+      .handleGraphQLErrors(onError)
+      .allocated
+
+  // Opens a connection and allocates a subscription on it. The Resource manages the
+  // connection lifetime. The returned cleanup action ends only the subscription.
+  protected def openSubscription(
+    bearerToken: Option[String],
+    query:       String,
+    variables:   Option[JsonObject]
+  ): Resource[IO, (Stream[IO, Json], IO[Unit])] =
+    streamingClient(bearerToken)(serverFixture())
+      .evalMap(allocateSubscription(_, query, variables))
+
   def subscription(
     bearerToken: Option[String],
     query: String,
@@ -166,12 +194,7 @@ abstract class BaseSuite extends CatsEffectSuite:
     Supervisor[IO].use: sup =>
       streamingClient(bearerToken)(serverFixture())
         .use: conn =>
-          val req = conn.subscribe(Operation(query))
-          variables
-            .fold(req.apply)(req.withInput)
-            .raiseFirstNoDataError
-            .handleGraphQLErrors(onError)
-            .allocated
+          allocateSubscription(conn, query, variables, onError)
             .flatMap: (sub, cleanup) =>
               for
                 fib <- sup.supervise(sub.compile.toList)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionCompleteSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionCompleteSuite.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.literal.*
+import org.http4s.headers.Authorization
+
+import scala.concurrent.duration.*
+
+// Tests that the server sends a `Complete` message when a subscription source stream ends
+// naturally, without the client initiating the close.
+
+class SubscriptionCompleteSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(VariablesMapping).some.pure[IO]
+
+  // VariablesMapping's Subscription.echo emits exactly 3 results and then ends.
+  private val echoQuery: String    = """subscription($abc: String) { echo(s: $abc) }"""
+  private val echoVars: JsonObject = Json.obj("abc" -> Json.fromString("foo")).asObject.get
+  private val expected: List[Json] = List.fill(3)(json"""{ "echo": "foo" }""")
+
+  test("server sends Complete when subscription source stream ends naturally"):
+    // We deliberately do NOT call the subscription cleanup (i.e., we never send
+    // client→server Complete).  The stream must terminate on its own because the
+    // server sends the Complete message.  Without the fix this times out.
+    openSubscription(none, echoQuery, echoVars.some).use: (sub, _) =>
+      sub.compile.toList
+        .timeout(5.seconds)
+        .assertEquals(expected)
+
+  test("id is removed from map after natural completion: client cleanup is a no-op"):
+    // After the stream ends naturally and the server sends Complete (removing the id),
+    // calling the client cleanup should be a harmless no-op (id is no longer in the
+    // server-side map, so no duplicate Complete is produced).
+    openSubscription(none, echoQuery, echoVars.some).use: (sub, cleanup) =>
+      for
+        obt <- sub.compile.toList.timeout(5.seconds)
+        _   <- cleanup
+      yield assertEquals(obt.map(_.spaces2), expected.map(_.spaces2))
+
+  test("server sends Complete for an immediately-finishing (empty) subscription stream"):
+    // Empty source stream: the fiber can complete before `subscriptions.update` inserts
+    // the entry (the start-before-insert race).  Without the fix, no Complete is ever sent
+    // and the client stream hangs; additionally a stale entry leaks in the map.
+    openSubscription(none, "subscription { empty }", none).use: (sub, _) =>
+      sub.compile.toList
+        .timeout(5.seconds)
+        .assertEquals(List.empty[Json])
+
+  test("explicit client Complete still works after the stream already ended"):
+    // The echo stream ends before the helper calls the client cleanup, so this covers the
+    // ordinary path: the server already sent Complete, and the late cleanup changes nothing.
+    subscription(
+      bearerToken = none,
+      query       = echoQuery,
+      mutations   = Right(IO.unit),
+      variables   = echoVars.some,
+    ).assertEquals(expected)
+
+  test("explicit client Complete interrupts a still-running subscription"):
+    // The `ticks` source stream never ends, so the client cleanup runs while the subscription
+    // is live.  This covers the interruptWhen path: remove() takes the map entry, sends
+    // Complete, and cancels the fiber.  The stream finalizer must not send a second Complete.
+    subscription(
+      bearerToken = none,
+      query       = "subscription { ticks }",
+      mutations   = Right(IO.unit),
+      variables   = none,
+    ).timeout(5.seconds).map: obt =>
+      assert(obt.nonEmpty, "expected at least one tick before the client cleanup ran")
+      assertEquals(obt.map(_.spaces2).distinct, List(json"""{ "ticks": "tick" }""".spaces2))

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.effect.testkit.TestControl
+import cats.implicits.*
+import cats.~>
+import clue.model.StreamingMessage.FromServer
+import clue.model.StreamingMessage.FromServer.*
+import fs2.Stream
+import grackle.Result
+import io.circe.Json
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration.*
+
+
+class SubscriptionsSuite extends CatsEffectSuite:
+
+  given Logger[IO] = BaseSuite.logger
+
+  // Runs one test program on the virtual clock.
+  private def run(io: IO[Unit]): IO[Unit] =
+    TestControl.executeEmbed(io)
+
+  private val settle: IO[Unit] =
+    IO.sleep(1.second)
+
+  // A short name for each message, so that a test can assert on the whole sequence.
+  private def label(m: FromServer): String = m match
+    case Next(id, _)             => s"next:$id"
+    case FromServer.Error(id, _) => s"error:$id"
+    case Complete(id)            => s"complete:$id"
+    case other                   => other.toString
+
+  private def recorder: IO[(Ref[IO, List[String]], Option[FromServer] => IO[Unit])] =
+    Ref[IO].of(List.empty[String]).map: ref =>
+      (ref, msg => msg.fold(IO.unit)(m => ref.update(_ :+ label(m))))
+
+  private val ok: Result[Json] = Result(Json.fromString("ok"))
+
+  private val delayingLogger: Logger[IO] =
+    BaseSuite.logger.mapK(new (IO ~> IO) { def apply[A](fa: IO[A]): IO[A] = IO.sleep(200.milliseconds) *> fa })
+
+  test("a stream that ends before the map entry exists still produces a Complete"):
+    given Logger[IO] = delayingLogger
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        _           <- subs.add("1", Stream(ok).covary[IO])
+        _           <- settle
+        obt         <- log.get
+      yield assertEquals(obt, List("next:1", "complete:1"))
+
+  test("a cancelled add leaves no subscription that removeAll cannot stop"):
+    given Logger[IO] = delayingLogger
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        f           <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok)).start
+        _           <- IO.sleep(100.milliseconds)
+        _           <- f.cancel
+        _           <- subs.removeAll
+        obt         <- log.get
+      yield assertEquals(obt.count(_ === "complete:1"), 1)
+
+  test("a stream that ends naturally produces one Complete after the results"):
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        _           <- subs.add("1", Stream(ok, ok).covary[IO])
+        _           <- settle
+        obt         <- log.get
+      yield assertEquals(obt, List("next:1", "next:1", "complete:1"))
+
+  test("no Complete follows an Error, because Error ends the operation"):
+    // `replySink` turns a Failure result into an Error message and the stream continues. The
+    // protocol makes Error terminal for an id, so the finalizer must not add a Complete.
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        _           <- subs.add("1", Stream(Result.failure[Json]("boom"), ok).covary[IO])
+        _           <- settle
+        obt         <- log.get
+      yield assertEquals(obt, List("error:1", "next:1"))
+
+  test("remove on a running subscription produces exactly one Complete"):
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        _           <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok))
+        _           <- IO.sleep(100.milliseconds)
+        _           <- subs.remove("1")
+        _           <- settle
+        obt         <- log.get
+      yield
+        assert(obt.count(_ === "next:1") >= 1, "the stream sent nothing before remove")
+        assertEquals(obt.count(_ === "complete:1"), 1)
+
+  test("the finalizer of a replaced subscription does not remove the live entry"):
+    // A duplicate id replaces the map entry. When the replaced stream ends, its finalizer must
+    // leave the new entry alone, so that removeAll can still cancel the new fiber.
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        ticks       <- Ref[IO].of(0)
+        release     <- Deferred[IO, Unit]
+        // Ends only when the test completes `release`.
+        _           <- subs.add("1", Stream.eval(release.get).drain)
+        // Replaces the entry for id "1" in the map.
+        _           <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).evalTap(_ => ticks.update(_ + 1)).as(ok))
+        _           <- IO.sleep(100.milliseconds)
+        _           <- release.complete(())
+        _           <- IO.sleep(100.milliseconds)
+        _           <- subs.removeAll
+        _           <- IO.sleep(100.milliseconds)
+        before      <- ticks.get
+        _           <- settle
+        after       <- ticks.get
+        obt         <- log.get
+      yield
+        assert(before >= 1, "the live stream sent nothing before removeAll")
+        assertEquals(after, before, "the fiber of the live subscription outlived removeAll")
+        assertEquals(obt.count(_ === "complete:1"), 1)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/VariablesSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/VariablesSuite.scala
@@ -9,6 +9,7 @@ import fs2.Stream
 import grackle.Query.Binding
 import grackle.QueryCompiler.Elab
 import grackle.QueryCompiler.SelectElaborator
+import grackle.Result
 import grackle.Schema
 import grackle.Value.StringValue
 import grackle.circe.CirceMapping
@@ -16,6 +17,8 @@ import grackle.syntax.*
 import io.circe.Json
 import io.circe.literal.*
 import org.http4s.headers.Authorization
+
+import scala.concurrent.duration.*
 
 import BaseSuite.ClientOption
 import BaseSuite.ClientOption.*
@@ -29,6 +32,8 @@ object VariablesMapping extends CirceMapping[IO]:
     }
     type Subscription {
       echo(s: String): String!
+      empty: String!
+      ticks: String!
     }
   """
   val QueryType        = schema.ref("Query")
@@ -40,7 +45,12 @@ object VariablesMapping extends CirceMapping[IO]:
     ObjectMapping(SubscriptionType, List(
       RootStream.computeJson("echo"): (_, e) =>
         val r = e.getR[String]("s").map(Json.fromString)
-        Stream(r, r, r).covary[IO]
+        Stream(r, r, r).covary[IO],
+      RootStream.computeJson("empty"): (_, _) =>
+        Stream.empty.covary[IO],
+      // A source stream that never ends, so a test can close the subscription while it runs.
+      RootStream.computeJson("ticks"): (_, _) =>
+        Stream.awakeEvery[IO](25.milliseconds).as(Result(Json.fromString("tick")))
     ))
   )
   override val selectElaborator = SelectElaborator:


### PR DESCRIPTION
When a subscription's source stream finishes on its own (e.g. a finite Stream of N elements, or Stream.empty), the server now sends a Complete message so the client knows the subscription is over, as required by the graphql-ws protocol.
