### PR TITLE
Follow the GraphQL-over-HTTP specification on the HTTP routes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val otel4sVersion              = "1.1.0"
 enablePlugins(NoPublishPlugin)
 
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.3.3")
-ThisBuild / tlBaseVersion       := "0.13"
+ThisBuild / tlBaseVersion       := "0.14"
 ThisBuild / scalaVersion        := "3.8.4"
 ThisBuild / crossScalaVersions  := Seq("3.8.4")
 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLService.scala
@@ -37,11 +37,18 @@ class GraphQLService[F[_]: {MonadThrow, Tracer as T}](
   def parse(query: String, op: Option[String], vars: Option[JsonObject]): Result[Operation] =
     mapping.compiler.compile(query, op, vars.map(_.toJson), reportUnused = false)
 
+  /**
+   * True if the GraphQL document parses. The HTTP routes use this to tell a syntax error, which
+   * gives status 400, from a validation error, which gives status 422.
+   */
+  def parses(document: String): Boolean =
+    mapping.graphQLParser.parseText(document).hasValue
+
   private val MaxDocumentLength = 1024
 
   private def truncateDocument(doc: String): String =
     if doc.length <= MaxDocumentLength then doc
-    else s"${doc.take(MaxDocumentLength)}... (truncated at $MaxDocumentLength} of ${doc.length} chars)"
+    else s"${doc.take(MaxDocumentLength)}... (truncated at $MaxDocumentLength of ${doc.length} chars)"
 
   // OTEL attributes for a GraphQL operation; see
   // https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/

--- a/modules/core/src/main/scala/lucuma/graphql/routes/ResponseMediaType.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/ResponseMediaType.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import grackle.Problem
+import io.circe.Json
+import io.circe.syntax.*
+import org.http4s.Charset
+import org.http4s.Headers
+import org.http4s.MediaType
+import org.http4s.QValue
+import org.http4s.Response
+import org.http4s.Status
+import org.http4s.circe.*
+import org.http4s.headers.Accept
+import org.http4s.headers.`Content-Type`
+
+/**
+ * The media type that the server selected for a response, as described by the GraphQL over HTTP
+ * specification.
+ *
+ * See https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md
+ */
+enum ResponseMediaType:
+
+  /** The client accepts `application/graphql-response+json`. */
+  case GraphQL
+
+  /**
+   * The client accepts `application/json` but not `application/graphql-response+json`. The
+   * specification calls such a client a legacy client.
+   */
+  case LegacyJson
+
+  /**
+   * The `Content-Type` header of a response with the given status.
+   *
+   * The specification asks for the GraphQL media type, except that a 2xx response to a legacy
+   * client carries `application/json`.
+   */
+  def contentType(status: Status): `Content-Type` =
+    val mediaType =
+      if this == ResponseMediaType.LegacyJson && status.isSuccess then ResponseMediaType.Json
+      else ResponseMediaType.GraphQLResponseJson
+    `Content-Type`(mediaType, Charset.`UTF-8`)
+
+  /**
+   * The status of a response that has both a `data` entry and an `errors` entry.
+   *
+   * The specification recommends status 294 together with the GraphQL media type, which gives the
+   * status its meaning. A legacy client does not get that media type on a 2xx response, so it gets
+   * status 200 instead.
+   */
+  def partialSuccessStatus: Status = this match
+    case ResponseMediaType.GraphQL    => ResponseMediaType.PartialSuccess
+    case ResponseMediaType.LegacyJson => Status.Ok
+
+  /** A response with the given status and the given GraphQL response body. */
+  def response[F[_]](status: Status, body: Json): Response[F] =
+    Response[F](status).withEntity(body).withContentType(contentType(status))
+
+  /** A response that carries the given error messages and no data. */
+  def errorResponse[F[_]](status: Status, messages: NonEmptyList[String]): Response[F] =
+    response[F](status, Json.obj("errors" -> messages.toList.map(m => Problem(m)).asJson))
+
+  /** A response that carries one error message and no data. */
+  def errorResponse[F[_]](status: Status, message: String): Response[F] =
+    errorResponse[F](status, NonEmptyList.one(message))
+
+object ResponseMediaType:
+
+  /** The media type for a GraphQL response. */
+  val GraphQLResponseJson: MediaType =
+    new MediaType("application", "graphql-response+json", compressible = true, binary = false)
+
+  /** The media type for a GraphQL request body, and for a response to a legacy client. */
+  val Json: MediaType =
+    MediaType.application.json
+
+  /**
+   * Status code 294, when the response has both a `data` entry and an `errors` entry.
+   */
+  val PartialSuccess: Status =
+    Status
+      .fromInt(294)
+      .getOrElse(throw new AssertionError("294 Partial Success is a valid status code"))
+
+  /**
+   * Select the media type for a response to a request with the given headers.
+   *
+   * The specification leaves the choice to the server when the request has no `Accept` header.
+   * This server then uses the GraphQL media type.
+   *
+   * A result of `None` means that the server supports no media type that the client accepts. The
+   * caller must then answer with status 406.
+   */
+  def negotiate(headers: Headers): Option[ResponseMediaType] =
+    headers.get[Accept] match
+      case None         => GraphQL.some
+      case Some(accept) =>
+        // Extract the highest q value of that media type
+        def priority(mediaType: MediaType): Option[QValue] =
+          accept.values.toList
+            .filter(entry => entry.mediaRange.satisfiedBy(mediaType) && entry.qValue > QValue.Zero)
+            .map(_.qValue)
+            .maximumOption
+
+        (priority(GraphQLResponseJson), priority(Json)) match
+          case (Some(graphQL), Some(json)) => (if json > graphQL then LegacyJson else GraphQL).some
+          case (Some(_), None)             => GraphQL.some
+          case (None, Some(_))             => LegacyJson.some
+          case (None, None)                => none

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -3,7 +3,7 @@
 
 package lucuma.graphql.routes
 
-import cats.data.Nested
+import cats.data.NonEmptyList
 import cats.data.ValidatedNel
 import cats.effect.*
 import cats.effect.std.Queue
@@ -19,13 +19,13 @@ import io.circe.syntax.*
 import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.HttpRoutes
-import org.http4s.InvalidMessageBodyFailure
 import org.http4s.MediaType
 import org.http4s.Method
 import org.http4s.ParseFailure
 import org.http4s.QueryParamDecoder
 import org.http4s.Request
 import org.http4s.Response
+import org.http4s.Status
 import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Allow
@@ -69,8 +69,25 @@ object Routes {
     object OperationNameMatcher extends OptionalQueryParamDecoderMatcher[String]("operationName")
     object VariablesMatcher     extends OptionalValidatingQueryParamDecoderMatcher[JsonObject]("variables")
 
-    def handler(req: Request[F]): F[Option[HttpRouteHandler[F]]] =
-      Nested(service(req.headers.get[Authorization])).map(new HttpRouteHandler(_)).value
+    // Select the media type of the response. The specification requires status 406 when the
+    // server supports no media type that the client accepts.
+    def negotiated(req: Request[F])(use: ResponseMediaType => F[Response[F]]): F[Response[F]] =
+      ResponseMediaType.negotiate(req.headers) match
+        case None    =>
+          // The client accepts no media type that can carry a GraphQL response, so this response
+          // carries plain text. The specification forbids the GraphQL media type here.
+          NotAcceptable(
+            s"This server supports the media types ${ResponseMediaType.GraphQLResponseJson} and ${ResponseMediaType.Json}."
+          )
+        case Some(t) => use(t)
+
+    // Select the response media type, then build a handler for the authorized service.
+    def withHandler(req: Request[F])(use: HttpRouteHandler[F] => F[Response[F]]): F[Response[F]] =
+      negotiated(req): t =>
+        service(req.headers.get[Authorization]).flatMap {
+          case Some(s) => use(new HttpRouteHandler(s, t))
+          case None    => t.errorResponse[F](Forbidden, "Access denied.").pure[F]
+        }
 
     def playground(rootPath: Path): F[Response[F]] =
       Ok(Playground((rootPath / graphQLPath).toString, (rootPath / wsPath).toString)).map(_.withContentType(`Content-Type`(MediaType.text.html)))
@@ -81,19 +98,24 @@ object Routes {
       case req @ GET -> Root / `graphQLPath` :?  QueryMatcher(query) +& OperationNameMatcher(op) +& VariablesMatcher(vars) =>
         T.span(s"GET /$graphQLPath").surround:
           debug"GET one off: query=$query, op=$op, vars=$vars" *>
-          handler(req).flatMap {
-            case Some(h) => h.oneOffGet(query, op, vars)
-            case None    => Forbidden("Access denied.")
-          }
+          withHandler(req)(_.oneOffGet(query, op, vars))
+
+      // A GET request without a `query` parameter is not a well-formed GraphQL-over-HTTP request.
+      // The specification asks for status 422.
+      case req @ GET -> Root / `graphQLPath` =>
+        T.span(s"GET /$graphQLPath").surround:
+          debug"GET one off: no query parameter" *>
+          negotiated(req): t =>
+            t.errorResponse[F](
+              UnprocessableContent,
+              "The request must have a `query` parameter."
+            ).pure[F]
 
       // GraphQL query is embedded in a Json request body when queried via POST
       case req @ POST -> Root / `graphQLPath` =>
         T.span(s"POST /$graphQLPath").surround:
           debug"POST one off: request=$req" *>
-          handler(req).flatMap {
-            case Some(h) => h.oneOffPost(req)
-            case None    => Forbidden("Access denied.")
-          }
+          withHandler(req)(_.oneOffPost(req))
 
       // WebSocket connection request.
       case req @ GET -> Root / `wsPath` =>
@@ -106,29 +128,89 @@ object Routes {
         T.span(s"GET /$playgroundPath").surround:
           playground(Path(req.uri.path.segments.dropRight(Path.unsafeFromString(playgroundPath).segments.length)).toAbsolute)
 
+      // The specification asks for status 405 when the request uses an unsupported method. RFC
+      // 9110 requires the `Allow` header with this status.
+      case req @ _ -> Root / `graphQLPath` =>
+        T.span(s"${req.method} /$graphQLPath").surround:
+          debug"Unsupported method ${req.method}" *>
+          negotiated(req): t =>
+            t.errorResponse[F](
+              MethodNotAllowed,
+              s"The method ${req.method.name} is not allowed. Use GET or POST."
+            ).putHeaders(Allow(Method.GET, Method.POST)).pure[F]
+
     }
   }
 
 }
 
-class HttpRouteHandler[F[_]: {Temporal, Tracer}](service: GraphQLService[F]) {
+class HttpRouteHandler[F[_]: {Temporal, Tracer}](
+  service:      GraphQLService[F],
+  acceptedType: ResponseMediaType
+) {
 
   val dsl: Http4sDsl[F] = new Http4sDsl[F]{}
   import dsl._
 
-  def toResponse(result: Result[Json]): F[Response[F]] =
-    Ok(service.mapping.mkResponse(result))
+  private def respond(status: Status, body: Json): F[Response[F]] =
+    acceptedType.response[F](status, body).pure[F]
+
+  // The status code of a GraphQL response, per the specification:
+  //   - data and no errors      -> 200 Ok
+  //   - data and errors         -> 294 Partial Success, or 200 Ok for a legacy client
+  //   - no data                 -> `failureStatus`, which the caller selects from the cause
+  private def statusFor(result: Result[Json], failureStatus: Status): Status =
+    result match {
+      case Result.Success(_)    => Ok
+      case Result.Warning(_, _) => acceptedType.partialSuccessStatus
+      case _                    => failureStatus
+    }
+
+  // Builds the response for a result. `mkResponse` raises the error of an internal error, which
+  // http4s turns into status 500.
+  def toResponse(result: Result[Json], failureStatus: Status = UnprocessableContent): F[Response[F]] =
+    service.mapping.mkResponse(result).flatMap(respond(statusFor(result, failureStatus), _))
+
+  // A response with a single error message and no data.
+  private def errorResponse(status: Status, message: String): F[Response[F]] =
+    acceptedType.errorResponse[F](status, message).pure[F]
+
+  // A response with several error messages and no data.
+  private def errorResponse(status: Status, messages: NonEmptyList[String]): F[Response[F]] =
+    acceptedType.errorResponse[F](status, messages).pure[F]
+
+  // The specification asks for status 400 when the GraphQL document does not parse, and status
+  // 422 when the document parses but the server cannot process the request.
+  private def parseFailureStatus(document: String): Status =
+    if service.parses(document) then UnprocessableContent else BadRequest
 
   // Returns a 422 Unprocessable Content response with a well-formed GraphQL JSON error body.
   // Used by both HTTP handlers to reject subscription operations.
   private def subscriptionRejection: F[Response[F]] =
-    UnprocessableContent(
-      service.mapping.mkResponse(
-        Result.failure[Json](
-          "Subscription operations are not supported over HTTP. Use the WebSocket transport."
-        )
-      )
+    errorResponse(
+      UnprocessableContent,
+      "Subscription operations are not supported over HTTP. Use the WebSocket transport."
     )
+
+  // Returns a 405 Method Not Allowed response with a well-formed GraphQL JSON error body. The
+  // specification does not permit a mutation on a GET request. RFC 9110 requires the `Allow`
+  // header with this status.
+  private def mutationRejection: F[Response[F]] =
+    errorResponse(
+      MethodNotAllowed,
+      "Mutation operations are not supported on a GET request. Use a POST request."
+    ).map(_.putHeaders(Allow(Method.POST)))
+
+  // Runs the operation and builds the response. A failure of the parse stage carries no
+  // operation, so its status comes from the document instead of from the execution stage.
+  private def execute(
+    parsed:   Result[Operation],
+    document: String
+  )(run: Operation => F[Result[Json]]): F[Response[F]] =
+    parsed match {
+      case f: Result.Failure => toResponse(f, parseFailureStatus(document))
+      case _                 => parsed.flatTraverse(run).flatMap(toResponse(_))
+    }
 
   // If the parsed operation is a subscription, return a 422 rejection immediately.
   // Otherwise invoke `proceed`.  Both Success and Warning carry an Operation value.
@@ -147,37 +229,62 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](service: GraphQLService[F]) {
     vars0: Option[ValidatedNel[ParseFailure, JsonObject]]
   ): F[Response[F]] =
     vars0.sequence.fold(
-      errors => Ok(errors.map(_.sanitized).mkString_("", ",", "")), // in GraphQL errors are reported in a 200 Ok response (!)
+      // A `variables` parameter that is not a JSON object is not a well-formed GraphQL-over-HTTP
+      // request. The specification asks for status 422.
+      errors => errorResponse(UnprocessableContent, errors.map(_.sanitized)),
       // GET carries no extensions, so no remote trace context to join.
       vars => {
         val parsed = service.parse(query, op, vars)
         rejectSubscription(parsed) {
           parsed match {
             // Per the GraphQL over HTTP spec, GET requests MUST NOT execute mutations.
-            // Respond with 405 Method Not Allowed and advertise POST as the allowed method.
-            case Result.Success(operation)    if service.isMutation(operation) => MethodNotAllowed(Allow(Method.POST))
-            case Result.Warning(_, operation) if service.isMutation(operation) => MethodNotAllowed(Allow(Method.POST))
-            case _ => parsed.flatTraverse(service.query(_, query, op)).flatMap(toResponse)
+            case Result.Success(operation)    if service.isMutation(operation) => mutationRejection
+            case Result.Warning(_, operation) if service.isMutation(operation) => mutationRejection
+            case _ => execute(parsed, query)(service.query(_, query, op))
           }
         }
       }
     )
 
   def oneOffPost(req: Request[F]): F[Response[F]] =
-    for {
-      body   <- req.as[Json]
-      obj    <- body.asObject.liftTo[F](InvalidMessageBodyFailure("Invalid GraphQL query"))
-      query  <- obj("query").flatMap(_.asString).liftTo[F](InvalidMessageBodyFailure("Missing query field"))
-      op      = obj("operationName").flatMap(_.asString)
-      vars    = obj("variables").flatMap(_.asObject)
-      ext     = obj("extensions").flatMap(_.asObject)
-      parsed  = service.parse(query, op, vars)
-      resp   <- rejectSubscription(parsed) {
-                  parsed.traverse(p => joinRemote(ext.traceCarrier)(service.query(p, query, op)))
-                    .map(_.flatten)
-                    .flatMap(toResponse)
-                }
-    } yield resp
+    // The specification requires support for `application/json` request bodies, and recommends
+    // status 415 for any other media type and for an absent header.
+    req.headers.get[`Content-Type`].map(_.mediaType) match {
+      case Some(mt) if ResponseMediaType.Json.satisfiedBy(mt) => post(req)
+      case Some(mt) => errorResponse(UnsupportedMediaType, s"Unsupported content type '$mt'. Use '${ResponseMediaType.Json}'.")
+      case None     => errorResponse(UnsupportedMediaType, s"A Content-Type header of '${ResponseMediaType.Json}' is required.")
+    }
+
+  private def post(req: Request[F]): F[Response[F]] =
+    req.attemptAs[Json].value.flatMap {
+      // The specification asks for status 400 when the JSON body of the request does not parse.
+      case Left(failure) => errorResponse(BadRequest, failure.message)
+      case Right(body)   => postBody(body)
+    }
+
+  private def postBody(body: Json): F[Response[F]] = {
+
+    // A body that is not a JSON object, or that has no `query` entry of type string, is not a
+    // well-formed GraphQL-over-HTTP request. The specification asks for status 422.
+    val request: Either[String, (JsonObject, String)] =
+      for {
+        obj   <- body.asObject.toRight("The request body must be a JSON object.")
+        query <- obj("query").flatMap(_.asString).toRight("The request body must have a `query` entry of type string.")
+      } yield (obj, query)
+
+    request.fold(
+      message => errorResponse(UnprocessableContent, message),
+      (obj, query) => {
+        val op     = obj("operationName").flatMap(_.asString)
+        val vars   = obj("variables").flatMap(_.asObject)
+        val ext    = obj("extensions").flatMap(_.asObject)
+        val parsed = service.parse(query, op, vars)
+        rejectSubscription(parsed) {
+          execute(parsed, query)(p => joinRemote(ext.traceCarrier)(service.query(p, query, op)))
+        }
+      }
+    )
+  }
 
 }
 

--- a/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/AuthSuite.scala
@@ -5,7 +5,6 @@ package lucuma.graphql.routes
 
 import cats.effect.*
 import cats.implicits.*
-import clue.HttpStatusException
 import clue.RemoteInitializationException
 import fs2.Stream
 import grackle.Result
@@ -13,9 +12,15 @@ import grackle.circe.CirceMapping
 import grackle.syntax.*
 import io.circe.Json
 import io.circe.literal.*
+import io.circe.parser
 import org.http4s.AuthScheme
 import org.http4s.Credentials
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Status
+import org.http4s.circe.*
 import org.http4s.headers.Authorization
+import org.typelevel.ci.*
 
 import BaseSuite.ClientOption
 import BaseSuite.ClientOption.*
@@ -65,11 +70,22 @@ class AuthSuite extends BaseSuite:
       variables   = None
     )
 
-  test("[http] Missing credentials should raise HttpStatusException."):
-    interceptIO[HttpStatusException](testQuery(None, Http)).map(e => assertEquals(e.status, 403))
+  // The 403 response carries a well-formed GraphQL response with the GraphQL media type, so the
+  // client reads the body and reports the errors in it.
+  test("[http] Missing credentials should raise ResponseException."):
+    interceptGraphQL("Access denied.")(testQuery(None, Http))
 
-  test("[http] Incorrect credentials should raise HttpStatusException."):
-    interceptIO[HttpStatusException](testQuery(Some("steve"), Http)).map(e => assertEquals(e.status, 403))
+  test("[http] Incorrect credentials should raise ResponseException."):
+    interceptGraphQL("Access denied.")(testQuery(Some("steve"), Http))
+
+  test("[http] Missing credentials give 403 with the GraphQL media type and an errors body."):
+    rawResponse(uri => Request[IO](Method.POST, uri).withEntity(json"""{"query": "query { foo }"}"""))
+      .map: (status, headers, body) =>
+        assertEquals(status, Status.Forbidden)
+        val contentType = headers.get(ci"Content-Type").map(_.head.value)
+        assert(contentType.exists(_.startsWith("application/graphql-response+json")), s"Got: $contentType")
+        val errors = parser.parse(body).toOption.flatMap(_.hcursor.downField("errors").as[List[Json]].toOption)
+        assertEquals(errors.map(_.size), Some(1), body)
 
   test("[http] Correct credentials should work."):
     testQuery(Some("bob"), Http)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
@@ -99,6 +99,14 @@ abstract class BaseSuite extends CatsEffectSuite:
       _  <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
     yield sc
 
+  // Send a request to the /graphql endpoint without any client-side interpretation, and return
+  // the status, the headers and the body text of the response. Use this to assert on the parts
+  // of the response that a GraphQL client hides, such as the status code and the media type.
+  protected def rawResponse(mkRequest: Http4sUri => Request[IO]): IO[(Status, Headers, String)] =
+    Resource.eval(IO(serverFixture()))
+      .flatMap(svr => JdkHttpClient.simple[IO].flatMap(_.run(mkRequest(svr.baseUri / "graphql"))))
+      .use(resp => resp.bodyText.compile.string.map((resp.status, resp.headers, _)))
+
   protected lazy val serverFixture: IOFixture[Server] =
     ResourceSuiteLocalFixture("server", server)
 

--- a/modules/core/src/test/scala/lucuma/graphql/routes/GetMutationSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/GetMutationSuite.scala
@@ -11,9 +11,11 @@ import grackle.circe.CirceMapping
 import grackle.syntax.*
 import io.circe.Encoder
 import io.circe.Json
+import io.circe.parser
 import org.http4s.*
 import org.http4s.headers.Allow
 import org.http4s.headers.Authorization
+import org.typelevel.ci.*
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -92,6 +94,18 @@ class GetMutationSuite extends BaseSuite:
     rawGet(mutationDoc).map { (_, allow) =>
       assertEquals(allow, Some(Allow(Method.POST)))
     }
+
+  // The specification requires a well-formed GraphQL response body with the GraphQL media type.
+  test("GET a mutation response carries a GraphQL errors body"):
+    rawResponse(uri => Request[IO](Method.GET, uri.withQueryParam("query", mutationDoc)))
+      .map { (_, headers, text) =>
+        val contentType = headers.get(ci"Content-Type").map(_.head.value)
+        assert(contentType.exists(_.startsWith("application/graphql-response+json")), s"Got: $contentType")
+        val body   = parser.parse(text).getOrElse(Json.Null)
+        val errors = body.hcursor.downField("errors").as[List[Json]].getOrElse(Nil)
+        assert(errors.nonEmpty, s"Expected an errors list, got: ${body.spaces2}")
+        assert(!body.hcursor.downField("data").succeeded, s"Expected no data, got: ${body.spaces2}")
+      }
 
   // This is the most important assertion: the mutation side-effect must NOT
   // happen when the request is rejected at the HTTP layer.

--- a/modules/core/src/test/scala/lucuma/graphql/routes/PostContentTypeSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/PostContentTypeSuite.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+import io.circe.parser
+import org.http4s.*
+import org.http4s.headers.Authorization
+import org.http4s.headers.`Content-Type`
+import org.typelevel.ci.*
+
+object PostContentTypeMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query { ping: String! }
+  """
+  val QueryType    = schema.ref("Query")
+  val typeMappings = TypeMappings.unchecked(
+    ObjectMapping(QueryType)(
+      CursorFieldJson("ping", _ => Result.success(Json.fromString("pong")), Nil)
+    )
+  )
+
+class PostContentTypeSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(PostContentTypeMapping).some.pure[IO]
+
+  private val body = """{"query":"query { ping }"}"""
+
+  // POST the body with the given `Content-Type` header value. An absent value removes the header,
+  // so the request goes out without one.
+  private def post(contentType: Option[String]): IO[(Status, Json)] =
+    rawResponse: uri =>
+      val req = Request[IO](Method.POST, uri).withEntity(body)
+      contentType.fold(req.removeHeader[`Content-Type`])(ct => req.putHeaders(Header.Raw(ci"Content-Type", ct)))
+    .map((status, _, text) => (status, parser.parse(text).getOrElse(Json.Null)))
+
+  // --- supported content types --------------------------------------------------
+
+  test("POST with application/json succeeds"):
+    post("application/json".some).map: (status, _) =>
+      assertEquals(status, Status.Ok)
+
+  test("POST with application/json and a charset parameter succeeds"):
+    post("application/json; charset=utf-8".some).map: (status, _) =>
+      assertEquals(status, Status.Ok)
+
+  // --- unsupported content types ------------------------------------------------
+
+  test("POST without a Content-Type header returns 415"):
+    post(none).map: (status, _) =>
+      assertEquals(status, Status.UnsupportedMediaType)
+
+  test("POST with text/plain returns 415"):
+    post("text/plain".some).map: (status, _) =>
+      assertEquals(status, Status.UnsupportedMediaType)
+
+  test("POST with application/graphql returns 415"):
+    post("application/graphql".some).map: (status, _) =>
+      assertEquals(status, Status.UnsupportedMediaType)
+
+  test("a 415 response carries a GraphQL errors body"):
+    post("text/plain".some).map: (_, json) =>
+      val errors = json.hcursor.downField("errors").as[List[Json]].getOrElse(Nil)
+      assert(errors.nonEmpty, s"Expected an errors list, got: ${json.spaces2}")
+
+  // A body with an unsupported media type must not reach the GraphQL service.
+  test("a 415 response does not execute the operation"):
+    post("text/plain".some).map: (_, json) =>
+      assert(!json.hcursor.downField("data").succeeded, s"Expected no data, got: ${json.spaces2}")
+
+  // --- GET carries no body, so it needs no Content-Type header --------------------
+
+  test("GET without a Content-Type header succeeds"):
+    rawResponse(uri => Request[IO](Method.GET, uri.withQueryParam("query", "query { ping }")))
+      .map((status, _, _) => assertEquals(status, Status.Ok))

--- a/modules/core/src/test/scala/lucuma/graphql/routes/RequestErrorSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/RequestErrorSuite.scala
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+import io.circe.parser
+import org.http4s.*
+import org.http4s.headers.Allow
+import org.http4s.headers.Authorization
+import org.http4s.headers.`Content-Type`
+import org.typelevel.ci.*
+
+// Mapping used by RequestErrorSuite. These tests never reach execution, so one query field is
+// enough.
+object RequestErrorMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query { ping: String! }
+  """
+  val QueryType    = schema.ref("Query")
+  val typeMappings = TypeMappings.unchecked(
+    ObjectMapping(QueryType)(
+      CursorFieldJson("ping", _ => Result.success(Json.fromString("pong")), Nil)
+    )
+  )
+
+// Tests the responses to a request that the server cannot process. Each response must carry a
+// well-formed GraphQL response body with the GraphQL media type (findings 14 and 20).
+class RequestErrorSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(RequestErrorMapping).some.pure[IO]
+
+  private val GraphQLJson = "application/graphql-response+json"
+
+  // The status, the headers and the parsed body of the response to the given request.
+  private def response(mkRequest: Uri => Request[IO]): IO[(Status, Headers, Json)] =
+    rawResponse(mkRequest).map: (status, headers, text) =>
+      (status, headers, parser.parse(text).getOrElse(Json.Null))
+
+  // POST the given text with a `Content-Type` header of `application/json`.
+  private def postText(text: String): IO[(Status, Headers, Json)] =
+    response: uri =>
+      Request[IO](Method.POST, uri)
+        .withEntity(text)
+        .putHeaders(`Content-Type`(MediaType.application.json))
+
+  private def get(params: (String, String)*): IO[(Status, Headers, Json)] =
+    response(uri => Request[IO](Method.GET, params.foldLeft(uri)((u, p) => u.withQueryParam(p._1, p._2))))
+
+  // Assert that the response carries the GraphQL media type and a non-empty `errors` list, and
+  // that it carries no `data` entry.
+  private def assertErrorBody(headers: Headers, body: Json): Unit =
+    val contentType = headers.get(ci"Content-Type").map(_.head.value)
+    assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+    val errors = body.hcursor.downField("errors").as[List[Json]].getOrElse(Nil)
+    assert(errors.nonEmpty, s"Expected an errors list, got: ${body.spaces2}")
+    assert(!body.hcursor.downField("data").succeeded, s"Expected no data, got: ${body.spaces2}")
+    errors.foreach: error =>
+      assert(error.hcursor.downField("message").as[String].isRight, s"Expected a message, got: ${error.spaces2}")
+
+  // --- GET ----------------------------------------------------------------------
+
+  test("GET without a query parameter returns 422 with an errors body"):
+    get().map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  // An empty document parses, but it holds no operation. The specification asks for status 422
+  // when the server cannot determine the operation to execute.
+  test("GET with an empty query parameter returns 422 with an errors body"):
+    get("query" -> "").map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  test("GET with a variables parameter that is not JSON returns 422 with an errors body"):
+    get("query" -> "query { ping }", "variables" -> "not json").map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  test("GET with a variables parameter that is not an object returns 422 with an errors body"):
+    get("query" -> "query { ping }", "variables" -> "[1,2,3]").map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  // --- POST ---------------------------------------------------------------------
+
+  test("POST with a body that is not JSON returns 400 with an errors body"):
+    postText("NONSENSE").map: (status, headers, body) =>
+      assertEquals(status, Status.BadRequest)
+      assertErrorBody(headers, body)
+
+  test("POST with a truncated JSON body returns 400 with an errors body"):
+    postText("""{"query":""").map: (status, headers, body) =>
+      assertEquals(status, Status.BadRequest)
+      assertErrorBody(headers, body)
+
+  test("POST with an empty body returns 400 with an errors body"):
+    postText("").map: (status, headers, body) =>
+      assertEquals(status, Status.BadRequest)
+      assertErrorBody(headers, body)
+
+  test("POST with a body that is not a JSON object returns 422 with an errors body"):
+    postText("""["query"]""").map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  test("POST without a query entry returns 422 with an errors body"):
+    postText("""{"qeury": "{__typename}"}""").map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  test("POST with a query entry that is not a string returns 422 with an errors body"):
+    postText("""{"query": 42}""").map: (status, headers, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertErrorBody(headers, body)
+
+  // --- unsupported methods --------------------------------------------------------
+
+  test("PUT returns 405 with an errors body"):
+    response(uri => Request[IO](Method.PUT, uri).withEntity("""{"query":"query { ping }"}"""))
+      .map: (status, headers, body) =>
+        assertEquals(status, Status.MethodNotAllowed)
+        assertErrorBody(headers, body)
+
+  test("PUT returns an Allow header with the supported methods"):
+    response(uri => Request[IO](Method.PUT, uri).withEntity("""{"query":"query { ping }"}"""))
+      .map: (_, headers, _) =>
+        assertEquals(headers.get[Allow], Allow(Method.GET, Method.POST).some)
+
+  test("DELETE returns 405 with an errors body"):
+    response(uri => Request[IO](Method.DELETE, uri)).map: (status, headers, body) =>
+      assertEquals(status, Status.MethodNotAllowed)
+      assertErrorBody(headers, body)
+
+  // --- a legacy client gets the same status codes ----------------------------------
+
+  test("a legacy client also gets 405 and the GraphQL media type on an error"):
+    response: uri =>
+      Request[IO](Method.PUT, uri).putHeaders(Header.Raw(ci"Accept", "application/json"))
+    .map: (status, headers, body) =>
+      assertEquals(status, Status.MethodNotAllowed)
+      assertErrorBody(headers, body)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ResponseMediaTypeSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ResponseMediaTypeSuite.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+import org.http4s.*
+import org.http4s.circe.*
+import org.http4s.headers.Authorization
+import org.typelevel.ci.*
+
+// Mapping used by ResponseMediaTypeSuite. A single query field is enough, because these tests
+// look at the `Content-Type` header of the response and not at the body.
+object ResponseMediaTypeMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query { ping: String! }
+  """
+  val QueryType    = schema.ref("Query")
+  val typeMappings = TypeMappings.unchecked(
+    ObjectMapping(QueryType)(
+      CursorFieldJson("ping", _ => Result.success(Json.fromString("pong")), Nil)
+    )
+  )
+
+// Tests the content negotiation of the GraphQL over HTTP specification (finding 15).
+class ResponseMediaTypeSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(ResponseMediaTypeMapping).some.pure[IO]
+
+  private val GraphQLJson = "application/graphql-response+json"
+  private val LegacyJson  = "application/json"
+
+  // POST a query with the given `Accept` header value. An absent value sends no header.
+  private def post(accept: Option[String], query: String = "query { ping }"): IO[(Status, Option[String])] =
+    rawResponse: uri =>
+      val req = Request[IO](Method.POST, uri).withEntity(Json.obj("query" -> Json.fromString(query)))
+      accept.fold(req)(a => req.putHeaders(Header.Raw(ci"Accept", a)))
+    .map((status, headers, _) => (status, headers.get(ci"Content-Type").map(_.head.value)))
+
+  private def get(accept: Option[String]): IO[(Status, Option[String])] =
+    rawResponse: uri =>
+      val req = Request[IO](Method.GET, uri.withQueryParam("query", "query { ping }"))
+      accept.fold(req)(a => req.putHeaders(Header.Raw(ci"Accept", a)))
+    .map((status, headers, _) => (status, headers.get(ci"Content-Type").map(_.head.value)))
+
+  // --- the server honors the Accept header ------------------------------------
+
+  test("Accept of the GraphQL media type gives the GraphQL media type"):
+    post(GraphQLJson.some).map: (status, contentType) =>
+      assertEquals(status, Status.Ok)
+      assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+
+  test("Accept of the legacy media type gives the legacy media type on a 200 response"):
+    post(LegacyJson.some).map: (status, contentType) =>
+      assertEquals(status, Status.Ok)
+      assert(contentType.exists(_.startsWith(LegacyJson)), s"Got: $contentType")
+      assert(!contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+
+  test("the server obeys the q value of the Accept header"):
+    post(s"$GraphQLJson;q=0.5, $LegacyJson;q=0.9".some).map: (_, contentType) =>
+      assert(contentType.exists(_.startsWith(LegacyJson)), s"Got: $contentType")
+
+  test("the server prefers the GraphQL media type at an equal q value"):
+    post(s"$LegacyJson, $GraphQLJson".some).map: (_, contentType) =>
+      assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+
+  test("a wildcard Accept gives the GraphQL media type"):
+    post("*/*".some).map: (_, contentType) =>
+      assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+
+  test("an absent Accept header gives the GraphQL media type"):
+    post(none).map: (_, contentType) =>
+      assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+
+  test("the response declares the utf-8 charset"):
+    post(GraphQLJson.some).map: (_, contentType) =>
+      assert(contentType.exists(_.toLowerCase.contains("charset=utf-8")), s"Got: $contentType")
+
+  // --- no acceptable media type -----------------------------------------------
+
+  test("an Accept header without a supported media type gives 406"):
+    post("text/html".some).map: (status, _) =>
+      assertEquals(status, Status.NotAcceptable)
+
+  test("a 406 response does not use the GraphQL media type"):
+    post("text/html".some).map: (_, contentType) =>
+      assert(!contentType.exists(_.contains("graphql-response+json")), s"Got: $contentType")
+
+  // A q value of 0 means that the client refuses the media type.
+  test("a q value of 0 for every supported media type gives 406"):
+    post(s"$GraphQLJson;q=0, $LegacyJson;q=0".some).map: (status, _) =>
+      assertEquals(status, Status.NotAcceptable)
+
+  // --- the legacy media type applies only to a 2xx response --------------------
+
+  test("a legacy client gets the GraphQL media type on an error response"):
+    post(LegacyJson.some, "query { nope }").map: (status, contentType) =>
+      assert(!status.isSuccess, s"Expected an error status, got: $status")
+      assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+
+  // --- GET negotiates in the same way -----------------------------------------
+
+  test("GET obeys the Accept header"):
+    get(LegacyJson.some).map: (status, contentType) =>
+      assertEquals(status, Status.Ok)
+      assert(contentType.exists(_.startsWith(LegacyJson)), s"Got: $contentType")
+
+  test("GET with an Accept header without a supported media type gives 406"):
+    get("text/html".some).map: (status, _) =>
+      assertEquals(status, Status.NotAcceptable)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ResponseStatusSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ResponseStatusSuite.scala
@@ -1,0 +1,178 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+import io.circe.parser
+import org.http4s.*
+import org.http4s.circe.*
+import org.http4s.headers.Authorization
+import org.typelevel.ci.*
+
+// Mapping used by ResponseStatusSuite. Each field gives one kind of result:
+//   ping         - a plain success
+//   nullableFail - a field error on a nullable field
+//   nonNullFail  - a field error on a non-null field
+object ResponseStatusMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query {
+      ping: String!
+      nullableFail: String
+      nonNullFail: String!
+    }
+  """
+  val QueryType    = schema.ref("Query")
+  val typeMappings = TypeMappings.unchecked(
+    ObjectMapping(QueryType)(
+      CursorFieldJson("ping", _ => Result.success(Json.fromString("pong")), Nil),
+      CursorFieldJson("nullableFail", _ => Result.failure("nullable boom"), Nil),
+      CursorFieldJson("nonNullFail", _ => Result.failure("non-null boom"), Nil)
+    )
+  )
+
+// Tests the status codes of the GraphQL over HTTP specification (finding 16).
+class ResponseStatusSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(ResponseStatusMapping).some.pure[IO]
+
+  private def post(query: String, operationName: Option[String] = None): IO[(Status, Json)] =
+    rawResponse: uri =>
+      val fields = List("query" -> Json.fromString(query)) ++
+        operationName.map(n => "operationName" -> Json.fromString(n))
+      Request[IO](Method.POST, uri).withEntity(Json.fromFields(fields))
+    .map((status, _, body) => (status, parser.parse(body).getOrElse(Json.Null)))
+
+  private def get(query: String): IO[(Status, Json)] =
+    rawResponse: uri =>
+      Request[IO](Method.GET, uri.withQueryParam("query", query))
+    .map((status, _, body) => (status, parser.parse(body).getOrElse(Json.Null)))
+
+  private def hasErrors(body: Json): Boolean =
+    body.hcursor.downField("errors").as[List[Json]].exists(_.nonEmpty)
+
+  private def hasData(body: Json): Boolean =
+    body.hcursor.downField("data").succeeded
+
+  // --- success ----------------------------------------------------------------
+
+  test("a successful query returns 200"):
+    post("query { ping }").map: (status, body) =>
+      assertEquals(status, Status.Ok)
+      assert(hasData(body), body.spaces2)
+      assert(!hasErrors(body), body.spaces2)
+
+  // --- partial success --------------------------------------------------------
+
+  // Grackle reports a field error as a null `data` entry. The `data` entry is present, so the
+  // specification asks for status 294 and forbids a 4xx or 5xx status.
+  test("a field error on a nullable field returns 294 with a null data entry"):
+    post("query { nullableFail }").map: (status, body) =>
+      assertEquals(status.code, 294)
+      assertEquals(body.hcursor.downField("data").as[Option[Json]], Right(None))
+      assert(hasErrors(body), body.spaces2)
+
+  test("a field error on a non-null field returns 294 with a null data entry"):
+    post("query { nonNullFail }").map: (status, body) =>
+      assertEquals(status.code, 294)
+      assertEquals(body.hcursor.downField("data").as[Option[Json]], Right(None))
+      assert(hasErrors(body), body.spaces2)
+
+  // A field error next to a field that succeeds still gives status 294.
+  test("a field error beside a successful field returns 294"):
+    post("query { ping nullableFail }").map: (status, body) =>
+      assertEquals(status.code, 294)
+      assert(hasData(body), body.spaces2)
+      assert(hasErrors(body), body.spaces2)
+
+  // The specification requires a 2xx status whenever the response carries a `data` entry.
+  test("status 294 is a 2xx status"):
+    post("query { nullableFail }").map: (status, _) =>
+      assert(status.isSuccess, s"Expected a 2xx status, got: $status")
+
+  test("a legacy client gets 200 for a response with data and errors"):
+    rawResponse: uri =>
+      Request[IO](Method.POST, uri)
+        .withEntity(Json.obj("query" -> Json.fromString("query { nullableFail }")))
+        .putHeaders(Header.Raw(ci"Accept", "application/json"))
+    .map: (status, headers, text) =>
+      val body = parser.parse(text).getOrElse(Json.Null)
+      assertEquals(status, Status.Ok)
+      assert(hasData(body), body.spaces2)
+      assert(hasErrors(body), body.spaces2)
+      val contentType = headers.get(ci"Content-Type").map(_.head.value)
+      assert(contentType.exists(_.startsWith("application/json")), s"Got: $contentType")
+
+  // --- request errors ---------------------------------------------------------
+
+  test("a document that does not parse returns 400"):
+    post("query {").map: (status, body) =>
+      assertEquals(status, Status.BadRequest)
+      assert(hasErrors(body), body.spaces2)
+      assert(!hasData(body), body.spaces2)
+
+  test("a document that fails validation returns 422"):
+    post("query { nope }").map: (status, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assert(hasErrors(body), body.spaces2)
+
+  test("an operation that cannot be determined returns 422"):
+    post("query A { ping } query B { ping }", "C".some).map: (status, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assert(hasErrors(body), body.spaces2)
+
+  test("a variable value that does not coerce returns 422"):
+    rawResponse: uri =>
+      Request[IO](Method.POST, uri).withEntity(
+        Json.obj(
+          "query"     -> Json.fromString("query Q($i: Int!) { ping }"),
+          "variables" -> Json.obj("i" -> Json.fromString("not an int"))
+        )
+      )
+    .map((status, _, _) => assertEquals(status, Status.UnprocessableContent))
+
+  // --- a result without data --------------------------------------------------
+
+  // Grackle keeps the `data` entry for a field error, so a response without `data` comes from a
+  // result that carries no value. The specification forbids a 2xx status for such a response.
+  test("a result without a value returns 422"):
+    new HttpRouteHandler(GraphQLService(ResponseStatusMapping), ResponseMediaType.GraphQL)
+      .toResponse(Result.failure[Json]("boom"))
+      .map(resp => assertEquals(resp.status, Status.UnprocessableContent))
+
+  // --- a clue client reads the body at each of these statuses -----------------
+
+  // The clue backend reads the body of a response with the GraphQL media type at every status
+  // code. These tests confirm that the errors reach the caller and not an HTTP status exception.
+
+  test("[clue] a field error in a 294 response surfaces as a GraphQL error"):
+    interceptGraphQL("nullable boom"):
+      this.query(none, "query { nullableFail }", none, BaseSuite.ClientOption.Http)
+
+  test("[clue] a validation error in a 422 response surfaces as a GraphQL error"):
+    interceptGraphQL("No field 'nope' for type Query"):
+      this.query(none, "query { nope }", none, BaseSuite.ClientOption.Http)
+
+  test("[clue] a successful query still returns data"):
+    this.query(none, "query { ping }", none, BaseSuite.ClientOption.Http)
+      .assertEquals(Json.obj("ping" -> Json.fromString("pong")))
+
+  // --- GET uses the same status codes -----------------------------------------
+
+  test("GET of a document that does not parse returns 400"):
+    get("query {").map: (status, _) =>
+      assertEquals(status, Status.BadRequest)
+
+  test("GET of a document that fails validation returns 422"):
+    get("query { nope }").map: (status, _) =>
+      assertEquals(status, Status.UnprocessableContent)
+
+  test("GET of a successful query returns 200"):
+    get("query { ping }").map: (status, _) =>
+      assertEquals(status, Status.Ok)


### PR DESCRIPTION
Responses now use the `application/graphql-response+json` media type and a status code that reflects the outcome. Previously a failed request still gave status 200 with `application/json`, which hid parse and validation failures from clients that check the status code.

The Accept header is honoured, and the media type with the highest q value is selected. A client that accepts only `application/json` is a legacy client: it keeps `application/json` and status 200 on success, and it never receives status 294. When no supported media type is accepted, the response is 406 with a plain-text body, because the specification forbids the GraphQL media type there. https://graphql.github.io/graphql-over-http/draft/#sec-Accept

Status codes are 200 for data without errors, 294 for data with errors, 400 when the request or the document does not parse, and 422 when the request is not well-formed or fails validation. An unsupported method, and a mutation over GET, give 405 with an Allow header. https://graphql.github.io/graphql-over-http/draft/#sec-Status-Codes

POST requires a `Content-Type` of `application/json`. Any other value, and an absent header, give status 415. https://graphql.github.io/graphql-over-http/draft/#sec-POST
