### PR TITLE
Send an Error to the client when a subscription stream fails

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
@@ -98,6 +98,14 @@ object Subscriptions {
                            err <- errorSent.get
                            _   <- send(Complete(id).some).whenA(own && !err)
                          yield ()
+            // A failure of the source stream is reported to the client as a terminal `error`
+            // message. No `complete` follows it.
+            error      = (t: Throwable) =>
+                           for
+                             own <- removeOwn
+                             err <- errorSent.get
+                             _   <- send(Error(id, mkGraphqlErrors(t)).some).whenA(own && !err)
+                           yield ()
             es         = events.through(replySink(id, errorSent)).interruptWhen(in)
             fiber     <- Deferred[F, Fiber[F, Throwable, Unit]]
             _         <- subscriptions.update(_.updated(id, new Subscription(fiber, r)))
@@ -105,7 +113,8 @@ object Subscriptions {
             f         <- es.compile.drain
                            .guaranteeCase:
                              case Outcome.Succeeded(_) => complete
-                             case _                    => removeOwn.void
+                             case Outcome.Errored(t)   => error(t)
+                             case Outcome.Canceled()   => removeOwn.void
                            .start
             _         <- fiber.complete(f)
             _         <- Logger[F].debug(s"started event stream $id")

--- a/modules/core/src/test/scala/lucuma/graphql/routes/StreamErrorSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/StreamErrorSuite.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import clue.ResponseException
+import fs2.Stream
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+import io.circe.literal.*
+import org.http4s.headers.Authorization
+
+object StreamErrorMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query { dummy: Boolean }
+    type Subscription { failing: String! }
+  """
+  val QueryType        = schema.ref("Query")
+  val SubscriptionType = schema.ref("Subscription")
+  val typeMappings = TypeMappings.unchecked(
+    ObjectMapping(SubscriptionType, List(
+      RootStream.computeJson("failing"): (_, _) =>
+        // Emits two results, then fails.
+        Stream(
+          Result.success(Json.fromString("first")),
+          Result.success(Json.fromString("second"))
+        ).covary[IO] ++
+          Stream.raiseError[IO](new RuntimeException("boom"))
+    ))
+  )
+
+class StreamErrorSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(StreamErrorMapping).some.pure[IO]
+
+  test("stream error: client receives partial results then an error message"):
+    for
+      errorRef <- IO.ref(Option.empty[ResponseException[Json]])
+      results  <- subscription(
+        bearerToken = none,
+        query       = "subscription { failing }",
+        mutations   = Right(IO.unit),
+        variables   = none,
+        onError     = e => errorRef.set(Some(e))
+      )
+      err      <- errorRef.get
+      _        = assertEquals(
+                   results,
+                   List(json"""{"failing":"first"}""", json"""{"failing":"second"}"""),
+                   "expected the two emitted results before the failure"
+                 )
+      _        = assert(err.isDefined, "expected a ResponseException to be delivered via onError")
+      _        = assert(
+                   err.exists(_.errors.head.message.contains("Internal Error")),
+                   s"unexpected error content: $err"
+                 )
+    yield ()

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
@@ -42,6 +42,8 @@ class SubscriptionsSuite extends CatsEffectSuite:
 
   private val ok: Result[Json] = Result(Json.fromString("ok"))
 
+  private def boom: Throwable = new RuntimeException("boom")
+
   private val delayingLogger: Logger[IO] =
     BaseSuite.logger.mapK(new (IO ~> IO) { def apply[A](fa: IO[A]): IO[A] = IO.sleep(200.milliseconds) *> fa })
 
@@ -78,6 +80,31 @@ class SubscriptionsSuite extends CatsEffectSuite:
         _           <- settle
         obt         <- log.get
       yield assertEquals(obt, List("next:1", "next:1", "complete:1"))
+
+  test("a stream that fails sends an Error after the results, and no Complete"):
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        _           <- subs.add("1", Stream(ok, ok).covary[IO] ++ Stream.raiseError[IO](boom))
+        _           <- settle
+        obt         <- log.get
+      yield assertEquals(obt, List("next:1", "next:1", "error:1"))
+
+  test("a stream that fails before the map entry exists still produces an Error"):
+    given Logger[IO] = delayingLogger
+    run:
+      for
+        (log, send) <- recorder
+        subs        <- Subscriptions[IO](send)
+        _           <- subs.add("1", Stream.raiseError[IO](boom))
+        _           <- settle
+        // A leaked entry would make one of these send a Complete for a dead subscription.
+        _           <- subs.remove("1")
+        _           <- subs.removeAll
+        _           <- settle
+        obt         <- log.get
+      yield assertEquals(obt, List("error:1"))
 
   test("no Complete follows an Error, because Error ends the operation"):
     // `replySink` turns a Failure result into an Error message and the stream continues. The


### PR DESCRIPTION
When the source stream of a subscription raised a Throwable, the fiber ended without a report to the client. The client received neither an error nor a complete message, so it waited for a result that never arrived.

The stream fiber now sends a terminal `error` message for that id. It stays silent if another caller already removed the subscription, or if an `error` already went to the client.