### PR TITLE
Remove the dead `DROPPED!` branch of the reply path

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -243,10 +243,7 @@ object Connection {
           // Creates the function used to send replies to the client. It just offers a message to
           // the reply queue and logs it.
           val reply: Option[Either[GraphQLWSError, FromServer]] => F[Unit] = { m =>
-            for {
-              b <- replyQueue.tryOffer(m)
-              _ <- debug"Subscriptions send $m ${if (b) "enqueued" else "DROPPED!"}"
-            } yield ()
+            replyQueue.offer(m) *> debug"Subscriptions send $m enqueued"
           }
 
           // Given an optional Authorization, get a service and start a subscription (if allowed)


### PR DESCRIPTION
`replyQueue` is unbounded, so `tryOffer` always succeeds and the `DROPPED!` log branch never executed. The reply path now uses `offer`, which does the same work on an unbounded queue.
