### PR TITLE
Reject a POST parameter of the wrong type with status 422

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -262,22 +262,35 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](
       case Right(body)   => postBody(body)
     }
 
+  // Reads an optional request parameter of the body. The specification gives a type to each
+  // parameter, and a parameter with the value `null` counts as absent. A parameter of the wrong
+  // type makes the request not well-formed.
+  private def optionalParam[A](
+    obj:  JsonObject,
+    name: String,
+    tpe:  String
+  )(read: Json => Option[A]): Either[NonEmptyList[String], Option[A]] =
+    obj(name).filterNot(_.isNull) match {
+      case None       => none.asRight
+      case Some(json) => read(json).map(_.some).toRight(NonEmptyList.one(s"The `$name` entry must be $tpe."))
+    }
+
   private def postBody(body: Json): F[Response[F]] = {
 
     // A body that is not a JSON object, or that has no `query` entry of type string, is not a
     // well-formed GraphQL-over-HTTP request. The specification asks for status 422.
-    val request: Either[String, (JsonObject, String)] =
-      for {
-        obj   <- body.asObject.toRight("The request body must be a JSON object.")
-        query <- obj("query").flatMap(_.asString).toRight("The request body must have a `query` entry of type string.")
-      } yield (obj, query)
+    val request = body.asObject.toRight(NonEmptyList.one("The request body must be a JSON object.")).flatMap(obj =>
+      (
+        obj("query").flatMap(_.asString).toRight(NonEmptyList.one("The request body must have a `query` entry of type string.")),
+        optionalParam(obj, "operationName", "a string")(_.asString),
+        optionalParam(obj, "variables", "a JSON object")(_.asObject),
+        optionalParam(obj, "extensions", "a JSON object")(_.asObject)
+      ).parTupled
+    )
 
     request.fold(
-      message => errorResponse(UnprocessableContent, message),
-      (obj, query) => {
-        val op     = obj("operationName").flatMap(_.asString)
-        val vars   = obj("variables").flatMap(_.asObject)
-        val ext    = obj("extensions").flatMap(_.asObject)
+      messages => errorResponse(UnprocessableContent, messages),
+      (query, op, vars, ext) => {
         val parsed = service.parse(query, op, vars)
         rejectSubscription(parsed) {
           execute(parsed, query)(p => joinRemote(ext.traceCarrier)(service.query(p, query, op)))

--- a/modules/core/src/test/scala/lucuma/graphql/routes/PostParameterSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/PostParameterSuite.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import cats.implicits.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.parser
+import org.http4s.*
+import org.http4s.headers.Authorization
+import org.http4s.headers.`Content-Type`
+
+class PostParameterSuite extends BaseSuite:
+
+  def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
+    GraphQLService(RequestErrorMapping).some.pure[IO]
+
+  private def post(text: String): IO[(Status, Json)] =
+    rawResponse: uri =>
+      Request[IO](Method.POST, uri)
+        .withEntity(text)
+        .putHeaders(`Content-Type`(MediaType.application.json))
+    .map((status, _, body) => (status, parser.parse(body).getOrElse(Json.Null)))
+
+  private def errorCount(body: Json): Int =
+    body.hcursor.downField("errors").as[List[Json]].getOrElse(Nil).length
+
+  private val pong: Json =
+    json"""{"data":{"ping":"pong"}}"""
+
+  // --- a parameter of the wrong type ----------------------------------------------
+
+  test("POST with an operationName that is not a string returns 422"):
+    post("""{"query":"query { ping }","operationName":42}""").map: (status, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertEquals(errorCount(body), 1)
+
+  test("POST with variables that are not a JSON object returns 422"):
+    post("""{"query":"query { ping }","variables":[1,2,3]}""").map: (status, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertEquals(errorCount(body), 1)
+
+  test("POST with extensions that are not a JSON object returns 422"):
+    post("""{"query":"query { ping }","extensions":"nope"}""").map: (status, body) =>
+      assertEquals(status, Status.UnprocessableContent)
+      assertEquals(errorCount(body), 1)
+
+  test("POST reports the errors of every parameter of the wrong type"):
+    post("""{"query":"query { ping }","operationName":42,"variables":[],"extensions":7}""")
+      .map: (status, body) =>
+        assertEquals(status, Status.UnprocessableContent)
+        assertEquals(errorCount(body), 3)
+
+  // --- a parameter with the value null counts as absent ----------------------------
+
+  test("POST with a null operationName executes the operation"):
+    post("""{"query":"query { ping }","operationName":null}""").map: (status, body) =>
+      assertEquals(status, Status.Ok)
+      assertEquals(body, pong)
+
+  test("POST with null variables and null extensions executes the operation"):
+    post("""{"query":"query { ping }","variables":null,"extensions":null}""").map: (status, body) =>
+      assertEquals(status, Status.Ok)
+      assertEquals(body, pong)
+
+  // --- a parameter of the right type still works -----------------------------------
+
+  test("POST with an operationName of type string executes the named operation"):
+    post("""{"query":"query Ping { ping }","operationName":"Ping"}""").map: (status, body) =>
+      assertEquals(status, Status.Ok)
+      assertEquals(body, pong)


### PR DESCRIPTION
`oneOffPost` read `operationName` with `flatMap(_.asString)`, and `variables` and `extensions` with `flatMap(_.asObject)`. A parameter of the wrong type fell out of the `Option` and the server executed the operation without it.

The specification gives a type to each request parameter, so a parameter of the wrong type makes the request not well-formed. Each parameter now gives status 422 when its type is wrong, and the response reports the errors of every wrong parameter. A parameter with the value `null` counts as absent.
