### PR TITLE
Improve message for unsupported `Accept` header values

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/ResponseMediaType.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/ResponseMediaType.scala
@@ -88,18 +88,20 @@ object ResponseMediaType:
       .fromInt(294)
       .getOrElse(throw new AssertionError("294 Partial Success is a valid status code"))
 
-  /**
-   * Select the media type for a response to a request with the given headers.
-   *
-   * The specification leaves the choice to the server when the request has no `Accept` header.
-   * This server then uses the GraphQL media type.
-   *
-   * A result of `None` means that the server supports no media type that the client accepts. The
-   * caller must then answer with status 406.
-   */
+  @deprecated("Use negotiateOrError, which carries the error message of a 406 response.", "0.14.1")
   def negotiate(headers: Headers): Option[ResponseMediaType] =
+    negotiateOrError(headers).toOption
+
+  /**
+   * Select the media type of a response from the `Accept` header of the request.
+   *
+   * A request without an `Accept` header comes from a legacy client.
+   *
+   * A result of `Left` carries an error message for a 406 response.
+   */
+  def negotiateOrError(headers: Headers): Either[String, ResponseMediaType] =
     headers.get[Accept] match
-      case None         => GraphQL.some
+      case None         => LegacyJson.asRight
       case Some(accept) =>
         // Extract the highest q value of that media type
         def priority(mediaType: MediaType): Option[QValue] =
@@ -109,7 +111,9 @@ object ResponseMediaType:
             .maximumOption
 
         (priority(GraphQLResponseJson), priority(Json)) match
-          case (Some(graphQL), Some(json)) => (if json > graphQL then LegacyJson else GraphQL).some
-          case (Some(_), None)             => GraphQL.some
-          case (None, Some(_))             => LegacyJson.some
-          case (None, None)                => none
+          case (Some(graphQL), Some(json)) => (if json > graphQL then LegacyJson else GraphQL).asRight
+          case (Some(_), None)             => GraphQL.asRight
+          case (None, Some(_))             => LegacyJson.asRight
+          case (None, None)                =>
+            val accepted = Accept.headerInstance.value(accept)
+            s"Unsupported 'Accept' header '$accepted'. Supported media types are '${GraphQLResponseJson.show}' and '${Json.show}'.".asLeft

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -76,14 +76,7 @@ object Routes {
     // Select the media type of the response. The specification requires status 406 when the
     // server supports no media type that the client accepts.
     def negotiated(req: Request[F])(use: ResponseMediaType => F[Response[F]]): F[Response[F]] =
-      ResponseMediaType.negotiate(req.headers) match
-        case None    =>
-          // The client accepts no media type that can carry a GraphQL response, so this response
-          // carries plain text. The specification forbids the GraphQL media type here.
-          NotAcceptable(
-            s"This server supports the media types ${ResponseMediaType.GraphQLResponseJson} and ${ResponseMediaType.Json}."
-          )
-        case Some(t) => use(t)
+      ResponseMediaType.negotiateOrError(req.headers).fold(NotAcceptable(_), use)
 
     // Select the response media type, then build a handler for the authorized service.
     def withHandler(req: Request[F])(use: HttpRouteHandler[F] => F[Response[F]]): F[Response[F]] =

--- a/modules/core/src/test/scala/lucuma/graphql/routes/NegotiateSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/NegotiateSuite.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.implicits.*
+import munit.FunSuite
+import org.http4s.Charset
+import org.http4s.Header
+import org.http4s.Headers
+import org.http4s.Status
+import org.typelevel.ci.*
+
+// Tests `ResponseMediaType.negotiate` and the media type of a response without an HTTP server.
+class NegotiateSuite extends FunSuite:
+
+  private val GraphQLJson = "application/graphql-response+json"
+  private val LegacyJson  = "application/json"
+
+  private def negotiate(accept: String*): Either[String, ResponseMediaType] =
+    ResponseMediaType.negotiateOrError(Headers(accept.map(a => Header.Raw(ci"Accept", a))*))
+
+  private def message(accept: String*): String =
+    negotiate(accept*).swap.getOrElse(fail(s"Expected no acceptable media type for ${accept.toList}"))
+
+  // --- the server selects a media type ----------------------------------------
+
+  test("an absent Accept header gives the legacy media type"):
+    assertEquals(negotiate(), ResponseMediaType.LegacyJson.asRight)
+
+  test("an empty Accept header gives the legacy media type"):
+    assertEquals(negotiate(""), ResponseMediaType.LegacyJson.asRight)
+
+  test("a wildcard gives the GraphQL media type"):
+    assertEquals(negotiate("*/*"), ResponseMediaType.GraphQL.asRight)
+
+  test("a subtype wildcard gives the GraphQL media type"):
+    assertEquals(negotiate("application/*"), ResponseMediaType.GraphQL.asRight)
+
+  test("an equal q value gives the GraphQL media type"):
+    assertEquals(negotiate(s"$LegacyJson, $GraphQLJson"), ResponseMediaType.GraphQL.asRight)
+
+  test("the higher q value wins"):
+    assertEquals(negotiate(s"$GraphQLJson;q=0.5, $LegacyJson;q=0.9"), ResponseMediaType.LegacyJson.asRight)
+
+  test("the smallest q value above zero still counts"):
+    assertEquals(negotiate(s"$GraphQLJson;q=0.001, $LegacyJson;q=0"), ResponseMediaType.GraphQL.asRight)
+
+  test("a q value of 0 removes one media type"):
+    assertEquals(negotiate(s"$GraphQLJson;q=0, $LegacyJson"), ResponseMediaType.LegacyJson.asRight)
+
+  test("two Accept headers combine"):
+    assertEquals(negotiate("text/html", LegacyJson), ResponseMediaType.LegacyJson.asRight)
+
+  // --- no acceptable media type -----------------------------------------------
+
+  test("an unsupported media type has no result"):
+    assert(negotiate("text/html").isLeft)
+
+  test("a q value of 0 for every supported media type has no result"):
+    assert(negotiate(s"$GraphQLJson;q=0, $LegacyJson;q=0").isLeft)
+
+  test("a wildcard with a q value of 0 has no result"):
+    assert(negotiate("*/*;q=0").isLeft)
+
+  test("the message keeps the subtype of the rejected media type"):
+    assertEquals(
+      message("text/html"),
+      s"Unsupported 'Accept' header 'text/html'. Supported media types are '$GraphQLJson' and '$LegacyJson'."
+    )
+
+  test("the message names every rejected media type"):
+    assertEquals(
+      message("text/html, image/png"),
+      s"Unsupported 'Accept' header 'text/html, image/png'. Supported media types are '$GraphQLJson' and '$LegacyJson'."
+    )
+
+  test("the message keeps a q value of 0"):
+    assertEquals(
+      message(s"$GraphQLJson;q=0, $LegacyJson;q=0"),
+      s"Unsupported 'Accept' header '$GraphQLJson;q=0, $LegacyJson;q=0'. Supported media types are '$GraphQLJson' and '$LegacyJson'."
+    )
+
+  // --- the media type of a response -------------------------------------------
+
+  test("the GraphQL media type applies to an error response"):
+    assertEquals(ResponseMediaType.GraphQL.contentType(Status.BadRequest).mediaType.show, GraphQLJson)
+
+  test("a legacy client gets the legacy media type on a 200 response"):
+    assertEquals(ResponseMediaType.LegacyJson.contentType(Status.Ok).mediaType.show, LegacyJson)
+
+  test("a legacy client gets the legacy media type on a 294 response"):
+    assertEquals(ResponseMediaType.LegacyJson.contentType(ResponseMediaType.PartialSuccess).mediaType.show, LegacyJson)
+
+  test("a legacy client gets the GraphQL media type on a 400 response"):
+    assertEquals(ResponseMediaType.LegacyJson.contentType(Status.BadRequest).mediaType.show, GraphQLJson)
+
+  test("the response declares the utf-8 charset"):
+    assertEquals(ResponseMediaType.GraphQL.contentType(Status.Ok).charset, Charset.`UTF-8`.some)
+
+  test("only the GraphQL media type carries status 294"):
+    assertEquals(ResponseMediaType.GraphQL.partialSuccessStatus, ResponseMediaType.PartialSuccess)
+    assertEquals(ResponseMediaType.LegacyJson.partialSuccessStatus, Status.Ok)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ResponseMediaTypeSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ResponseMediaTypeSuite.scala
@@ -74,9 +74,10 @@ class ResponseMediaTypeSuite extends BaseSuite:
     post("*/*".some).map: (_, contentType) =>
       assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
 
-  test("an absent Accept header gives the GraphQL media type"):
-    post(none).map: (_, contentType) =>
-      assert(contentType.exists(_.startsWith(GraphQLJson)), s"Got: $contentType")
+  test("an absent Accept header gives the legacy media type"):
+    post(none).map: (status, contentType) =>
+      assertEquals(status, Status.Ok)
+      assert(contentType.exists(_.startsWith(LegacyJson)), s"Got: $contentType")
 
   test("the response declares the utf-8 charset"):
     post(GraphQLJson.some).map: (_, contentType) =>
@@ -91,6 +92,14 @@ class ResponseMediaTypeSuite extends BaseSuite:
   test("a 406 response does not use the GraphQL media type"):
     post("text/html".some).map: (_, contentType) =>
       assert(!contentType.exists(_.contains("graphql-response+json")), s"Got: $contentType")
+
+  test("a 406 response carries the message of the negotiation"):
+    rawResponse: uri =>
+      Request[IO](Method.POST, uri)
+        .withEntity(Json.obj("query" -> Json.fromString("query { ping }")))
+        .putHeaders(Header.Raw(ci"Accept", "text/html"))
+    .map: (_, _, body) =>
+      assertEquals(body, s"Unsupported 'Accept' header 'text/html'. Supported media types are '$GraphQLJson' and '$LegacyJson'.")
 
   // A q value of 0 means that the client refuses the media type.
   test("a q value of 0 for every supported media type gives 406"):

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ResponseStatusSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ResponseStatusSuite.scala
@@ -42,16 +42,20 @@ class ResponseStatusSuite extends BaseSuite:
   def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
     GraphQLService(ResponseStatusMapping).some.pure[IO]
 
+  // A request without an `Accept` header counts as a legacy client, which never gets status 294.
+  // These tests are about the status of a modern client, so they ask for the GraphQL media type.
+  private val AcceptGraphQL = Header.Raw(ci"Accept", "application/graphql-response+json")
+
   private def post(query: String, operationName: Option[String] = None): IO[(Status, Json)] =
     rawResponse: uri =>
       val fields = List("query" -> Json.fromString(query)) ++
         operationName.map(n => "operationName" -> Json.fromString(n))
-      Request[IO](Method.POST, uri).withEntity(Json.fromFields(fields))
+      Request[IO](Method.POST, uri).withEntity(Json.fromFields(fields)).putHeaders(AcceptGraphQL)
     .map((status, _, body) => (status, parser.parse(body).getOrElse(Json.Null)))
 
   private def get(query: String): IO[(Status, Json)] =
     rawResponse: uri =>
-      Request[IO](Method.GET, uri.withQueryParam("query", query))
+      Request[IO](Method.GET, uri.withQueryParam("query", query)).putHeaders(AcceptGraphQL)
     .map((status, _, body) => (status, parser.parse(body).getOrElse(Json.Null)))
 
   private def hasErrors(body: Json): Boolean =
@@ -106,6 +110,16 @@ class ResponseStatusSuite extends BaseSuite:
       assertEquals(status, Status.Ok)
       assert(hasData(body), body.spaces2)
       assert(hasErrors(body), body.spaces2)
+      val contentType = headers.get(ci"Content-Type").map(_.head.value)
+      assert(contentType.exists(_.startsWith("application/json")), s"Got: $contentType")
+
+  test("a request without an Accept header gets 200 for a response with data and errors"):
+    rawResponse: uri =>
+      Request[IO](Method.POST, uri)
+        .withEntity(Json.obj("query" -> Json.fromString("query { nullableFail }")))
+    .map: (status, headers, text) =>
+      assertEquals(status, Status.Ok)
+      assert(hasErrors(parser.parse(text).getOrElse(Json.Null)))
       val contentType = headers.get(ci"Content-Type").map(_.head.value)
       assert(contentType.exists(_.startsWith("application/json")), s"Got: $contentType")
 


### PR DESCRIPTION
And use `application/json` as the default when there is no `Accept` header