### PR TITLE
Rework the WebSocket subscription and reply lifecycle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core.*
+
 val catsEffectVersion          = "3.7.1"
 val circeVersion               = "0.14.16"
 val clueVersion                = "0.58.0"
@@ -45,5 +47,14 @@ lazy val core = project
       "org.typelevel" %% "grackle-circe"               % grackleVersion             % Test,
       "org.typelevel" %% "log4cats-slf4j"              % log4catsVersion            % Test,
       "org.typelevel" %% "munit-cats-effect"           % munitCatsEffectVersion     % Test
-    )
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("lucuma.graphql.routes.Connection.*"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("lucuma.graphql.routes.Connection.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("lucuma.graphql.routes.Subscriptions.*"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("lucuma.graphql.routes.Subscriptions#Subscription.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("lucuma.graphql.routes.Subscriptions#Subscription.*"),
+      ProblemFilters.exclude[MissingClassProblem]("lucuma.graphql.routes.package"),
+      ProblemFilters.exclude[MissingClassProblem]("lucuma.graphql.routes.package$")
+    ),
   )

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -7,7 +7,9 @@ import cats.MonadError
 import cats.MonadThrow
 import cats.effect.Concurrent
 import cats.effect.Ref
+import cats.effect.Resource
 import cats.effect.std.Queue
+import cats.effect.std.Supervisor
 import cats.syntax.all.*
 import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.*
@@ -16,7 +18,6 @@ import clue.model.StreamingMessage.FromServer.*
 import grackle.Operation
 import grackle.Result.*
 import io.circe.JsonObject
-import lucuma.graphql.routes.mkGraphqlError
 import org.http4s.ParseResult
 import org.http4s.headers.Authorization
 import org.typelevel.log4cats.Logger
@@ -55,15 +56,16 @@ object Connection {
      */
     def reset(
       service: GraphQLService[F],
-      send: Option[Either[GraphQLWSError, FromServer]] => F[Unit],
+      send: Reply => F[Unit],
       subs: Subscriptions[F]
     ): (ConnectionState[F], F[Unit])
 
     /**
-     * Starts a Graph QL operation associated with a particular id.
-     * @return state transition and action to execute
+     * Starts a GraphQL operation associated with a particular id.
+     * @return state transition and action to execute. The action returns the error that must
+     *         close the connection, if any.
      */
-    def start(id:  String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit])
+    def start(id:  String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Option[GraphQLWSError]])
 
     /**
      * Terminates a Graph QL subscription associated with a particular id
@@ -79,28 +81,32 @@ object Connection {
 
   }
 
+  // The last reply of a connection. It ends the reply stream, which closes the socket.
+  private def lastReply(reason: Option[GraphQLWSError]): Reply =
+    reason.fold(Reply.End)(Reply.CloseWith(_))
+
   /**
    * PendingInit state. Initial state, awaiting `connection_init` message that contains the user
    * authorization header. Once it receives it, we transition to `Connected`.
    */
   def pendingInit[F[_]: Logger: Tracer](
-    replyQueue: Queue[F, Option[Either[GraphQLWSError, FromServer]]]
+    replyQueue: Queue[F, Reply]
   )(implicit ev: MonadError[F, Throwable]): ConnectionState[F] =
 
     new ConnectionState[F] {
 
       override def reset(
         service: GraphQLService[F],
-        send: Option[Either[GraphQLWSError, FromServer]] => F[Unit],
+        send: Reply => F[Unit],
         subs: Subscriptions[F],
       ): (ConnectionState[F], F[Unit]) =
         (connected(service, send, subs),
-         send(ConnectionAck().asRight.some) *> send(FromServer.Ping().asRight.some)
+         send(Reply.Send(ConnectionAck())) *> send(Reply.Send(FromServer.Ping()))
         )
 
 
-      override def start(id: String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) =
-        doClose(s"start($id, $req)")
+      override def start(id: String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Option[GraphQLWSError]]) =
+        doClose(s"start($id, $req)").map(_.as(none))
 
       override def stop(id: String): (ConnectionState[F], F[Unit]) =
         doClose(s"stop($id)")
@@ -109,7 +115,7 @@ object Connection {
         close(GraphQLWSError.Unauthorized(m).some)
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
-        (closed, replyQueue.offer(reason.map(_.asLeft)))
+        (closed, replyQueue.offer(lastReply(reason)))
 
     }
 
@@ -119,7 +125,7 @@ object Connection {
    */
   def connected[F[_]: {Logger, MonadThrow, Tracer as T}](
     service:       GraphQLService[F],
-    send:          Option[Either[GraphQLWSError, FromServer]] => F[Unit],
+    send:          Reply => F[Unit],
     subscriptions: Subscriptions[F]
   ): ConnectionState[F] =
 
@@ -127,24 +133,24 @@ object Connection {
 
       override def reset(
         service: GraphQLService[F],
-        r: Option[Either[GraphQLWSError, FromServer]] => F[Unit],
+        r: Reply => F[Unit],
         s: Subscriptions[F]
       ): (ConnectionState[F], F[Unit]) =
         (connected(service, r, s),
           subscriptions.removeAll  *>
-            r(ConnectionAck().asRight.some) *>
-            r(FromServer.Ping().asRight.some)
+            r(Reply.Send(ConnectionAck())) *>
+            r(Reply.Send(FromServer.Ping()))
         )
 
-      override def start(id: String, raw: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) = {
+      override def start(id: String, raw: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Option[GraphQLWSError]]) = {
         val document    = raw.query.value
         val parseResult = service.parse(document, raw.operationName, raw.variables)
         val name        = raw.operationName
         val action = parseResult match {
           case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, document, name) else execute(id, op, document, name)
           case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, document, name) else execute(id, op, document, name) // n.b. warnings on subscribe are lost
-          case Failure(ps)        => send(Error(id, ps.toNonEmptyList.map(mkGraphqlError)).asRight.some)
-          case InternalError(err) => send(Error(id, mkGraphqlErrors(err)).asRight.some)
+          case Failure(ps)        => send(Reply.Send(Error(id, mkGraphqlErrors(ps)))).as(none)
+          case InternalError(err) => send(Reply.Send(Error(id, mkGraphqlErrors(err)))).as(none)
         }
         // Re-parent server spans on the client's remote context
         // This is valid if the client span has a W3C traceparent value in extensions)
@@ -154,74 +160,96 @@ object Connection {
       override def stop(id: String): (ConnectionState[F], F[Unit]) =
         (this, subscriptions.remove(id))
 
+      // The attributes that the span of every client operation carries.
+      private def inOperationSpan[A](id: String)(fa: F[A]): F[A] =
+        T.withCurrentSpanOrNoop: span =>
+          span.addAttributes(Attribute("connection.fromclient.id", id)) >>
+            span.addAttributes(service.props*) >>
+            fa
+
+      // The protocol reserves close code 4409 for a `subscribe` message that uses an id that is
+      // already active. The subscription map reports the duplicate and the connection closes.
       def subscribe(
         id:            String,
         request:       Operation,
         document:      String,
         operationName: Option[String]
-      ): F[Unit] =
-        T.withCurrentSpanOrNoop: span =>
-          span.addAttributes(Attribute("connection.fromclient.id", id)) >>
-            span.addAttributes(service.props*) >>
-            subscriptions.add(id, service.subscribe(request, document, operationName))
+      ): F[Option[GraphQLWSError]] =
+        inOperationSpan(id):
+          subscriptions.add(id, service.subscribe(request, document, operationName)).map: added =>
+            Option.unless(added)(GraphQLWSError.SubscriberAlreadyExists(id))
 
       def execute(
         id:            String,
         request:       Operation,
         document:      String,
         operationName: Option[String]
-      ): F[Unit] =
-        T.withCurrentSpanOrNoop: span =>
-          span.addAttributes(Attribute("connection.fromclient.id", id)) >>
-            span.addAttributes(service.props*) >>
-            service.query(request, document, operationName).flatMap { r =>
-              mkFromServer(r, id).flatMap {
-                case Right(data) => send(data.asRight.some) *> send(FromServer.Complete(id).asRight.some)
-                case Left(error) => send(error.asRight.some)
-              }
+      ): F[Option[GraphQLWSError]] =
+        inOperationSpan(id):
+          service.query(request, document, operationName).flatMap { r =>
+            mkFromServer(r, id).flatMap {
+              case Right(data) => send(Reply.Send(data)) *> send(Reply.Send(FromServer.Complete(id)))
+              case Left(error) => send(Reply.Send(error))
             }
+          }.as(none)
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
-        (closed, subscriptions.removeAll *> send(reason.map(_.asLeft)))
+        (closed, subscriptions.removeAll *> send(lastReply(reason)))
     }
 
-  /** Closed state.  All requests raise an error, the connection having been closed. */
-  def closed[F[_]: MonadThrow as M]: ConnectionState[F] =
+  /**
+   * Closed state. The connection put its last reply on the queue, so it ignores every message
+   * that follows. A client can have messages in flight when the server closes the connection. An
+   * error here fails the socket before the close frame reaches the client, and the client sees an
+   * abnormal close with no code.
+   */
+  def closed[F[_]: {Logger, MonadThrow as M}]: ConnectionState[F] =
 
     new ConnectionState[F] {
 
-      private val raiseError: (ConnectionState[F], F[Unit]) =
-        (this, M.raiseError(new RuntimeException("Connection was terminated.")))
+      private def ignore[A](m: String)(a: A): (ConnectionState[F], F[A]) =
+        (this, debug"Ignoring $m because the connection closed.".as(a))
 
       override def reset(
         service: GraphQLService[F],
-        r: Option[Either[GraphQLWSError, FromServer]] => F[Unit],
+        r: Reply => F[Unit],
         s: Subscriptions[F]
       ): (ConnectionState[F], F[Unit]) =
-        raiseError
+        ignore("connection_init")(())
 
-      override def start(id: String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Unit]) =
-        raiseError
+      override def start(id: String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Option[GraphQLWSError]]) =
+        ignore(s"subscribe($id)")(none[GraphQLWSError])
 
       override def stop(id: String): (ConnectionState[F], F[Unit]) =
-        raiseError
+        ignore(s"complete($id)")(())
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
         (this, M.unit)
     }
 
-
-  def apply[F[_]: {Logger, Tracer as T}](
+  def apply[F[_]: {Concurrent, Logger, Tracer as T}](
     service: Option[Authorization] => F[Option[GraphQLService[F]]],
-    replyQueue: Queue[F, Option[Either[GraphQLWSError, FromServer]]]
-  )(implicit F: Concurrent[F]): F[Connection[F]] =
+    replyQueue: Queue[F, Reply]
+  ): Resource[F, Connection[F]] =
+    Supervisor[F].flatMap(supervisor => Resource.make(build(service, replyQueue, supervisor))(_.close))
+
+  private def build[F[_]: {Concurrent, Logger, Tracer as T}](
+    service: Option[Authorization] => F[Option[GraphQLService[F]]],
+    replyQueue: Queue[F, Reply],
+    supervisor: Supervisor[F]
+  ): F[Connection[F]] =
 
     Ref.of(pendingInit[F](replyQueue)).map { stateRef =>
 
       new Connection[F] {
 
-        def handle(f: ConnectionState[F] => (ConnectionState[F], F[Unit])): F[Unit] =
+        def handle[A](f: ConnectionState[F] => (ConnectionState[F], F[A])): F[A] =
           stateRef.modify(f).flatten
+
+        // The one way to send a reply to the client. It offers the reply to the queue and logs it.
+        val reply: Reply => F[Unit] = { m =>
+          replyQueue.offer(m) *> debug"Reply $m enqueued"
+        }
 
         def parseAuthorization(
           connectionProps: JsonObject
@@ -240,12 +268,6 @@ object Connection {
          */
         def init(connectionProps: Option[JsonObject]): F[Unit] = T.span("connection.init").surround {
 
-          // Creates the function used to send replies to the client. It just offers a message to
-          // the reply queue and logs it.
-          val reply: Option[Either[GraphQLWSError, FromServer]] => F[Unit] = { m =>
-            replyQueue.offer(m) *> debug"Subscriptions send $m enqueued"
-          }
-
           // Given an optional Authorization, get a service and start a subscription (if allowed)
           def trySubscribe(opAuth: Option[Authorization]): F[Unit] =
             service(opAuth).flatMap {
@@ -254,7 +276,8 @@ object Connection {
               case Some(svc) =>
                 T.withCurrentSpanOrNoop:
                   _.addAttributes(svc.props*) >>
-                    Subscriptions(msg => reply(msg.map(_.asRight))).flatMap(s => handle(_.reset(svc, reply, s)))
+                    Subscriptions(supervisor, msg => reply(Reply.Send(msg)))
+                      .flatMap(s => handle(_.reset(svc, reply, s)))
 
               // User has insufficient privileges to connect.
               case None =>
@@ -285,9 +308,9 @@ object Connection {
           debug"received $m" *> {
             m match {
               case ConnectionInit(m)       => init(m)
-              case Subscribe(id, request)  => handle(_.start(id, request))
+              case Subscribe(id, request)  => handle(_.start(id, request)).flatMap(_.traverse_(e => handle(_.close(e.some))))
               case FromClient.Complete(id) => handle(_.stop(id))
-              case FromClient.Ping(_)      => replyQueue.offer(FromServer.Pong().asRight.some)
+              case FromClient.Ping(_)      => reply(Reply.Send(FromServer.Pong()))
               case FromClient.Pong(_)      => debug"Received Pong from client"
             }
           }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLWSError.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLWSError.scala
@@ -8,5 +8,5 @@ enum GraphQLWSError(val code: Int, val reason: String):
   case Unauthorized(request: String) extends GraphQLWSError(4401, s"Unauthorized. Request '$request' received on un-initialized connection.")
   case Forbidden(msg: String) extends GraphQLWSError(4403, s"Forbidden: $msg")
   case InitializationTimeout extends GraphQLWSError(4408, "Connection initialization timeout") // TODO Not implemented yet 
-  case SubscriberAlreadyExists(id: String) extends GraphQLWSError(4409, s"Subscriber with id '$id' already exists") // TODO Not implemented yet 
+  case SubscriberAlreadyExists(id: String) extends GraphQLWSError(4409, s"Subscriber with id '$id' already exists")
   case TooManyInitializationRequests extends GraphQLWSError(4429, "Too many initialization requests") // TODO Not implemented yet 

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Reply.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Reply.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import clue.model.StreamingMessage.FromServer
+
+/**
+ * An item on the reply queue of a connection. `CloseWith` and `End` are terminal: the reply
+ * stream ends after either of them, which closes the socket and stops the keepalive stream.
+ */
+enum Reply:
+
+  /** A GraphQL message for the client. */
+  case Send(message: FromServer)
+
+  /** A close frame that carries an error code, and the last reply of the connection. */
+  case CloseWith(error: GraphQLWSError)
+
+  /** The last reply of the connection, without a close frame. */
+  case End
+
+  /** True for a reply that ends the reply stream. */
+  def isTerminal: Boolean = this match
+    case Send(_)      => false
+    case CloseWith(_) => true
+    case End          => true

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -11,6 +11,7 @@ import cats.implicits.*
 import clue.model.StreamingMessage.FromClient
 import clue.model.StreamingMessage.FromServer
 import clue.model.json.given
+import fs2.Pipe
 import fs2.Stream
 import grackle.Operation
 import grackle.Result
@@ -300,75 +301,104 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](
 
 }
 
+object WsRouteHandler {
+
+  // The connection_init message payload has authorization information
+  // which should not be logged.
+  private val AuthRegEx    = """("Authorization":)\s*"[^"]*"""".r.unanchored
+  private val RedactedAuth = """$1 <REDACTED>"""
+
+  /** Replaces the value of the `Authorization` property of a client message with a marker. */
+  private def redactAuth(s: String): String =
+    AuthRegEx.replaceFirstIn(s, RedactedAuth)
+
+}
+
 class WsRouteHandler[F[_]: {Logger as L, Temporal, Tracer as T}](service: Option[Authorization] => F[Option[GraphQLService[F]]]) {
+  import WsRouteHandler.redactAuth
 
   val KeepAliveDuration: FiniteDuration =
     5.seconds
 
   def webSocketConnection(wsb: WebSocketBuilder2[F]): F[Response[F]] = T.span("graphql.routes.webSocketConnection").surround {
 
-    val keepAliveStream: Stream[F, FromServer] =
+    // The keepalive Ping is a constant, so it is encoded once for the lifetime of the handler.
+    val pingFrame: WebSocketFrame =
+      Text(FromServer.Ping().asJson.noSpaces)
+
+    val keepAliveStream: Stream[F, Reply] =
       Stream
-        .constant[F, FromServer](FromServer.Ping())
+        .constant[F, Reply](Reply.Send(FromServer.Ping()))
         .metered(KeepAliveDuration)
 
-    def logFromServer(msg: Either[GraphQLWSError, FromServer]): F[Unit] =
-      msg match {
-        case Left(err)                 => warn"Sending error to client: ${err.code} ${err.reason} - Closing connection"
-        case Right(FromServer.Ping(_)) => debug"Sending Ping"
-        case Right(msg)                => debug"Sending to client: ${trimmedMessage(msg)}"
-      }
-
-    def logWebSocketFrame(f: WebSocketFrame): F[Unit] = {
-
-      // The connection_init message payload has authorization information
-      // which should not be logged.
-      val AuthRegEx    = """("Authorization":)\s*"[^"]*"""".r.unanchored
-      val RedactedAuth = """$1 <REDACTED>"""
-
+    def logWebSocketFrame(f: WebSocketFrame): F[Unit] =
       f match {
-        case Text(s, last) => debug"Received Text frame (last=$last) from client: ${AuthRegEx.replaceFirstIn(s, RedactedAuth)}"
+        case Text(s, last) => debug"Received Text frame (last=$last) from client: ${redactAuth(s)}"
         case _             => debug"Received message from client: $f"
       }
-    }
 
-    def trimmedMessage(m: FromServer): String = {
-      val s = m.asJson.spaces2
+    def trimmed(s: String): String =
       if (s.length > 516) s"${s.take(512)} ..." else s
-    }
 
-    for {
-      replyQueue <- Queue.unbounded[F, Option[Either[GraphQLWSError, FromServer]]]
-      connection <- Connection(service, replyQueue)
-      response   <- wsb.withHeaders(Headers(Header.Raw(CIString("Sec-WebSocket-Protocol"), "graphql-transport-ws"))).build(
+    // The frame for a reply, and the log line that goes with it. The message is encoded once.
+    // `CloseWith` carries a code that the protocol reserves, so the close frame is well-formed.
+    // A code that http4s rejects produces no frame, and the end of the reply stream still closes
+    // the socket.
+    val toFrames: Pipe[F, Reply, WebSocketFrame] =
+      _.evalMapFilter[F, WebSocketFrame] {
+        case Reply.Send(FromServer.Ping(None)) =>
+          debug"Sending Ping".as(pingFrame.some)
+        case Reply.Send(m)                     =>
+          val s = m.asJson.noSpaces
+          debug"Sending to client: ${trimmed(s)}".as(Text(s).some)
+        case Reply.CloseWith(err)              =>
+          warn"Sending error to client: ${err.code} ${err.reason} - Closing connection"
+            .as(Close(err.code, err.reason).orElse(Close(err.code)).toOption)
+        case Reply.End                         =>
+          debug"Ending the reply stream - Closing connection".as(none)
+      }
 
-          // Replies to client
-          Stream
-            .fromQueueNoneTerminated(replyQueue)
-            .mergeHaltL(keepAliveStream.map(_.asRight))
-            .evalTap(logFromServer)
-            .map{
-              case Left(err) => Close(err.code, err.reason).orElse(Close(err.code)).toOption.get
-              case Right(m)  => Text(m.asJson.spaces2)
-            },
+    // Replies to the client. A terminal reply ends the stream, so `mergeHaltL` then stops the
+    // keepalive stream, and no Ping follows the close frame.
+    def replies(replyQueue: Queue[F, Reply]): Stream[F, WebSocketFrame] =
+      Stream
+        .fromQueueUnterminated(replyQueue)
+        .takeThrough(!_.isTerminal)
+        .through(toFrames)
+        .mergeHaltL(keepAliveStream.through(toFrames))
 
-          // Input from client
-          _.evalTap(logWebSocketFrame)
-            .evalMap {
-              case Text(s, _) =>
-                scala.util.Try(parser.decode[FromClient](s)).toEither.flatten.fold(
-                  e => Concurrent[F].raiseError[Unit](new RuntimeException(s"Could not parse client message $s as FromClient: $e")),
-                  m => connection.receive(m)
-                )
+    // Input from the client. A frame that the server cannot handle fails the stream.
+    def receive(connection: Connection[F]): Pipe[F, WebSocketFrame, Nothing] =
+      _.evalTap(logWebSocketFrame)
+        .evalMap {
+          case Text(s, _) =>
+            Either.catchNonFatal(parser.decode[FromClient](s)).flatten.fold(
+              e => Concurrent[F].raiseError[Unit](new RuntimeException(s"Could not parse client message $s as FromClient: $e")),
+              m => connection.receive(m)
+            )
 
-              case Close(_)   =>
-                connection.close
+          case Close(_)   =>
+            connection.close
 
-              case f          =>
-                Concurrent[F].raiseError[Unit](new RuntimeException(s"Expected a Text WebSocketFrame from Client, but got $f"))
-            }
-        )
-    } yield response
+          case f          =>
+            Concurrent[F].raiseError[Unit](new RuntimeException(s"Expected a Text WebSocketFrame from Client, but got $f"))
+        }
+        .drain
+
+    // The reply queue and the connection live inside the stream, so fs2 owns their lifetime. A
+    // build that never opens a socket leaks nothing, because the stream never runs.
+    // `mergeHaltBoth` ends the socket when either side ends, which closes the connection and
+    // cancels every subscription. An abrupt disconnect takes the same path.
+    val sendReceive: Pipe[F, WebSocketFrame, WebSocketFrame] = in =>
+      for {
+        replyQueue <- Stream.eval(Queue.unbounded[F, Reply])
+        connection <- Stream.resource(Connection(service, replyQueue))
+        frame      <- replies(replyQueue).mergeHaltBoth(in.through(receive(connection)))
+      } yield frame
+
+    wsb
+      .withHeaders(Headers(Header.Raw(CIString("Sec-WebSocket-Protocol"), "graphql-transport-ws")))
+      .build(sendReceive)
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
@@ -3,19 +3,19 @@
 
 package lucuma.graphql.routes
 
-import cats.Monad
+import cats.FlatMap
 import cats.effect.Concurrent
 import cats.effect.Deferred
 import cats.effect.Fiber
-import cats.effect.Outcome
 import cats.effect.Ref
-import cats.effect.syntax.all.*
+import cats.effect.Resource.ExitCase
+import cats.effect.implicits.*
+import cats.effect.std.Supervisor
 import cats.implicits.*
 import clue.model.StreamingMessage.*
 import clue.model.StreamingMessage.FromServer.*
 import fs2.Pipe
 import fs2.Stream
-import fs2.concurrent.SignallingRef
 import grackle.Result
 import io.circe.Json
 import org.typelevel.log4cats.Logger
@@ -25,14 +25,20 @@ trait Subscriptions[F[_]] {
 
   /**
    * Adds a new subscription receiving events from the provided `Stream`.
-   * @param id     client-provided id for the subscription
-   * @param events stream of Either errors or Json results that match the subscription query
+   * @param id
+   *   client-provided id for the subscription
+   * @param events
+   *   stream of Either errors or Json results that match the subscription query
+   * @return
+   *   true if the event stream started, false if the id is already in use. The caller decides what
+   *   a duplicate id means for the connection.
    */
-  def add(id: String, events: Stream[F, Result[Json]]): F[Unit]
+  def add(id: String, events: Stream[F, Result[Json]]): F[Boolean]
 
   /**
    * Removes a subscription so that it no longer provides events to the client.
-   * @param id client-provided id
+   * @param id
+   *   client-provided id
    */
   def remove(id: String): F[Unit]
 
@@ -45,90 +51,113 @@ object Subscriptions {
 
   /**
    * Tracks a single client subscription.
-   * @param results Underlying stream of results, each of which is an Either error or subscription
-   *  query match
-   * @param stopped Set to true to interrupt the stream. Also identifies the subscription.
+   * @param fiber
+   *   Holds the fiber of the event stream once the map entry for the subscription exists. The event
+   *   stream waits for it, so the stream cannot end before the entry that its finalizer must clean
+   *   up exists.
+   * @param errorSent
+   *   True once an `error` message went to the client for this id.
    */
-  private final class Subscription[F[_]: Monad](
-    val results: Deferred[F, Fiber[F, Throwable, Unit]],
-    val stopped: SignallingRef[F, Boolean]
+  private final class Subscription[F[_]: FlatMap](
+    val fiber:     Deferred[F, Fiber[F, Throwable, Unit]],
+    val errorSent: Ref[F, Boolean]
   ) {
-
-    val stop: F[Unit] =
-      for {
-        _ <- stopped.set(true)
-        f <- results.get
-        _ <- f.cancel
-      } yield ()
-
+    val stop: F[Unit] = fiber.get.flatMap(_.cancel)
   }
 
   def apply[F[_]: Logger: Concurrent](
-    send: Option[FromServer] => F[Unit]
+    supervisor: Supervisor[F],
+    send:       FromServer => F[Unit]
   ): F[Subscriptions[F]] =
 
     Ref[F].of(Map.empty[String, Subscription[F]]).map { subscriptions =>
       new Subscriptions[F]() {
+        // The caller that takes an entry out of the map owns the `Complete` for that id, unless
+        // an `error` message already went to the client.
+        private def stopAndComplete(id: String, s: Subscription[F]): F[Unit] =
+          (s.stop *> s.errorSent.get.flatMap(err => send(Complete(id)).unlessA(err)))
+            .handleErrorWith(t => Logger[F].warn(t)(s"could not remove subscription $id"))
 
-        // The caller that takes an entry out of the map owns the `Complete` for that id.
-        def stopAndComplete(id: String, s: Subscription[F]): F[Unit] =
-          s.stop *> send(Some(Complete(id)))
+        /**
+         * Inserts a new subscription and starts its event stream. If the id is already in use, the
+         * stream does not start and the map does not change.
+         */
+        private def insertAndStart(
+          id:    String,
+          entry: Subscription[F],
+          run:   F[Unit]
+        ): F[Boolean] =
+          subscriptions.flatModify: m =>
+            if (m.contains(id))
+              (
+                m,
+                Logger[F].debug(s"duplicate subscription id $id").as(false)
+              )
+            else
+              (m.updated(id, entry),
+               for
+                 _     <- Logger[F].debug(s"starting event stream $id")
+                 fiber <- supervisor.supervise(run)
+                 _     <- entry.fiber.complete(fiber)
+                 _     <- Logger[F].debug(s"started event stream $id")
+               yield true
+              )
 
         // `errorSent` records that an `error` message went to the client for this id. The
-        // protocol makes `error` a terminal message, so no `complete` can follow it.
-        def replySink(id: String, errorSent: Ref[F, Boolean]): Pipe[F, Result[Json], Unit] =
-          _.evalMap { r =>
-            for {
-              e <- mkFromServer(r, id)
-              _ <- errorSent.set(true).whenA(e.isLeft)
-              _ <- send(Some(e.merge))
-            } yield ()
-          }
+        // protocol makes `error` a terminal message, so the stream ends after the first `error`
+        // and no `complete` can follow it. The send, the flag and the removal from the map form
+        // one uncancelable step. The client can reuse the id as soon as it has the `error`
+        // message, so the entry must not outlive that message.
+        private def replySink(
+          id:        String,
+          errorSent: Ref[F, Boolean],
+          removeOwn: F[Boolean]
+        ): Pipe[F, Result[Json], Unit] =
+          _.evalMap(mkFromServer(_, id))
+            .takeThrough(_.isRight)
+            .evalMap {
+              case Left(e)  => (send(e) *> errorSent.set(true) *> removeOwn.void).uncancelable
+              case Right(n) => send(n)
+            }
 
-        override def add(id: String, events: Stream[F, Result[Json]]): F[Unit] =
+        override def add(id: String, events: Stream[F, Result[Json]]): F[Boolean] =
           (for {
-            r         <- SignallingRef(false)
-            errorSent <- Ref[F].of(false)
-            in         = r.discrete.evalTap(v => Logger[F].debug(s"signalling ref = $v"))
-            removeOwn  = subscriptions.modify: m =>
-                            if (m.get(id).exists(_.stopped eq r)) (m.removed(id), true)
-                            else (m, false)
-            complete   = for
-                           own <- removeOwn
-                           err <- errorSent.get
-                           _   <- send(Complete(id).some).whenA(own && !err)
-                         yield ()
-            // A failure of the source stream is reported to the client as a terminal `error`
-            // message. No `complete` follows it.
-            error      = (t: Throwable) =>
-                           for
-                             own <- removeOwn
-                             err <- errorSent.get
-                             _   <- send(Error(id, mkGraphqlErrors(t)).some).whenA(own && !err)
-                           yield ()
-            es         = events.through(replySink(id, errorSent)).interruptWhen(in)
-            fiber     <- Deferred[F, Fiber[F, Throwable, Unit]]
-            _         <- subscriptions.update(_.updated(id, new Subscription(fiber, r)))
-            _         <- Logger[F].debug(s"starting event stream $id")
-            f         <- es.compile.drain
-                           .guaranteeCase:
-                             case Outcome.Succeeded(_) => complete
-                             case Outcome.Errored(t)   => error(t)
-                             case Outcome.Canceled()   => removeOwn.void
-                           .start
-            _         <- fiber.complete(f)
-            _         <- Logger[F].debug(s"started event stream $id")
-          } yield ()).uncancelable // cancellation before fiber.complete would block every stop
+            errorSent   <- Ref[F].of(false)
+            fiberD      <- Deferred[F, Fiber[F, Throwable, Unit]]
+            entry        = new Subscription(fiberD, errorSent)
+            removeOwn    = subscriptions.modify: m =>
+                             if (m.get(id).exists(_ eq entry)) (m.removed(id), true)
+                             else (m, false)
+            // The terminal message for this id, unless another caller took the entry out of
+            // the map or a terminal `error` message already went to the client.
+            sendLast     = (m: FromServer) =>
+                             for
+                               own <- removeOwn
+                               err <- errorSent.get
+                               _   <- send(m).whenA(own && !err)
+                             yield ()
+            // The stream waits for its own fiber, so it cannot end before its map entry
+            // exists. A natural end sends `complete` and a failure sends a terminal `error`.
+            // Cancellation sends nothing, because the canceller owns the `complete` for the id.
+            subscription = (Stream.exec(fiberD.get.void) ++
+                             events.through(replySink(id, errorSent, removeOwn)))
+                             .onFinalizeCase {
+                               case ExitCase.Succeeded  => sendLast(Complete(id))
+                               case ExitCase.Errored(t) => sendLast(Error(id, mkGraphqlErrors(t)))
+                               case ExitCase.Canceled   => removeOwn.void
+                             }
+                             .compile
+                             .drain
+            result      <- insertAndStart(id, entry, subscription)
+          } yield result).uncancelable
 
         override def remove(id: String): F[Unit] =
-          subscriptions
-            .getAndUpdate(_.removed(id))
-            .flatMap(_.get(id).traverse_(stopAndComplete(id, _)))
+          subscriptions.flatModifyFull: (poll, s) =>
+            (s.removed(id), s.get(id).traverse_(sub => poll(stopAndComplete(id, sub))))
 
         override def removeAll: F[Unit] =
-          subscriptions
-            .getAndSet(Map.empty[String, Subscription[F]])
-            .flatMap(_.toList.traverse_((id, s) => stopAndComplete(id, s)))
+          subscriptions.flatModifyFull: (poll, s) =>
+            (Map.empty, poll(s.toList.parTraverse_(stopAndComplete(_, _))))
 
       }
     }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/package.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.graphql
+package lucuma.graphql.routes
 
 import cats.MonadThrow
 import cats.data.Ior
@@ -17,42 +17,37 @@ import grackle.Result.*
 import io.circe.Json
 import org.typelevel.otel4s.trace.Tracer
 
-package object routes {
+// Extract W3C trace context headers (traceparent, tracestate) from the GraphQL
+// `extensions` object so otel4s can re-parent spans on the client.
+extension (extensions: Option[GraphQLExtensions])
+  private[routes] def traceCarrier: Map[String, String] =
+    extensions.fold(Map.empty):
+      _.toMap
+        .collect { case (k, v) if v.isString => k -> v.asString.orEmpty }
+        .filter((_, v) => v.nonEmpty)
 
-  // Extract W3C trace context headers (traceparent, tracestate) from the GraphQL
-  // `extensions` object so otel4s can re-parent spans on the client.
-  extension (extensions: Option[GraphQLExtensions])
-    private[routes] def traceCarrier: Map[String, String] =
-      extensions.fold(Map.empty):
-        _.toMap
-          .collect { case (k, v) if v.isString => k -> v.asString.orEmpty }
-          .filter((_, v) => v.nonEmpty)
+// Only call it when we have a remote context; otherwise keep the current span context.
+private[routes] def joinRemote[F[_]: Tracer, A](carrier: Map[String, String])(fa: F[A]): F[A] =
+  if carrier.contains("traceparent") then Tracer[F].joinOrRoot(carrier)(fa) else fa
 
-  // Only call it when we have a remote context; otherwise keep the current span context.
-  private[routes] def joinRemote[F[_]: Tracer, A](carrier: Map[String, String])(fa: F[A]): F[A] =
-    if carrier.contains("traceparent") then Tracer[F].joinOrRoot(carrier)(fa) else fa
+def mkGraphqlError(p: Problem): GraphQLError =
+  GraphQLError(
+    p.message,
+    NonEmptyList.fromList(p.path.map(GraphQLError.PathElement.string)),
+    NonEmptyList.fromList(p.locations.map(GraphQLError.Location(_, _))),
+    p.extensions
+  )
 
+def mkGraphqlErrors(problems: NonEmptyChain[Problem]): GraphQLErrors =
+  problems.toNonEmptyList.map(mkGraphqlError)
 
-  def mkGraphqlError(p: Problem): GraphQLError =
-    GraphQLError(
-      p.message,
-      NonEmptyList.fromList(p.path.map(GraphQLError.PathElement.string)),
-      NonEmptyList.fromList(p.locations.map { case (x, y) => GraphQLError.Location(x, y) }),
-      p.extensions,
-    )
+def mkGraphqlErrors(error: Throwable): GraphQLErrors =
+  NonEmptyList.one(mkGraphqlError(Problem(s"Internal Error: ${error.getMessage}")))
 
-  def mkGraphqlErrors(problems: NonEmptyChain[Problem]): GraphQLErrors =
-    problems.toNonEmptyList.map(mkGraphqlError)
-
-  def mkGraphqlErrors(error: Throwable): GraphQLErrors =
-    NonEmptyList.one(mkGraphqlError(Problem(s"Internal Error: ${error.getMessage}")))
-
-  def mkFromServer[F[_]: MonadThrow](r: Result[Json], id: String): F[Either[FromServer.Error, FromServer.Next]] =
-    r match {
-      case Success(json)      => FromServer.Next(id, GraphQLResponse(json.rightIor)).asRight.pure[F]
-      case Warning(ps, json)  => FromServer.Next(id, GraphQLResponse(Ior.both(mkGraphqlErrors(ps), json))).asRight.pure[F]
-      case Failure(ps)        => FromServer.Error(id, mkGraphqlErrors(ps)).asLeft.pure[F]
-      case InternalError(err) => FromServer.Error(id, mkGraphqlErrors(err)).asLeft.pure[F]
-    }
-
-}
+def mkFromServer[F[_]: MonadThrow](r: Result[Json], id: String): F[Either[FromServer.Error, FromServer.Next]] =
+  r match {
+    case Success(json)      => FromServer.Next(id, GraphQLResponse(json.rightIor)).asRight.pure[F]
+    case Warning(ps, json)  => FromServer.Next(id, GraphQLResponse(Ior.both(mkGraphqlErrors(ps), json))).asRight.pure[F]
+    case Failure(ps)        => FromServer.Error(id, mkGraphqlErrors(ps)).asLeft.pure[F]
+    case InternalError(err) => FromServer.Error(id, mkGraphqlErrors(err)).asLeft.pure[F]
+  }

--- a/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/BaseSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.graphql.routes
 
 import cats.effect.*
+import cats.effect.std.Queue
 import cats.effect.std.Supervisor
 import cats.effect.unsafe.IORuntime
 import cats.effect.unsafe.IORuntimeConfig
@@ -57,6 +58,16 @@ object BaseSuite:
     case e => print("OdbSuite.reportFailure: "); e.printStackTrace
 
   val logger: Logger[IO] = Slf4jLogger.getLoggerFromName("lucuma-odb-test")
+
+  // An in-process connection and its reply queue. There is no socket and no server, so a test
+  // can send client messages to the connection and read the replies straight off the queue.
+  def connectionResource(
+    service: Option[Authorization] => IO[Option[GraphQLService[IO]]]
+  )(using Logger[IO], Tracer[IO]): Resource[IO, (Connection[IO], Queue[IO, Reply])] =
+    for
+      queue <- Resource.eval(Queue.unbounded[IO, Reply])
+      conn  <- Connection[IO](service, queue)
+    yield (conn, queue)
 
   // a runtime that is constructed the same as global, but lets us see unhandled errors (above)
   val runtime: IORuntime =

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionPingSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionPingSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.graphql.routes
 
 import cats.effect.IO
+import cats.effect.Resource
 import cats.effect.std.Queue
 import cats.syntax.all.*
 import clue.model.StreamingMessage.FromClient
@@ -12,7 +13,6 @@ import io.circe.Json
 import io.circe.JsonObject
 import munit.CatsEffectSuite
 import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.otel4s.trace.Tracer
 
 /**
@@ -22,38 +22,33 @@ import org.typelevel.otel4s.trace.Tracer
  */
 final class ConnectionPingSuite extends CatsEffectSuite:
 
-  private type Reply = Option[Either[GraphQLWSError, FromServer]]
-
-  given Logger[IO] = Slf4jLogger.getLoggerFromName("lucuma-graphql-routes-test")
+  given Logger[IO] = BaseSuite.logger
   given Tracer[IO] = Tracer.noop[IO]
 
   /** A connection whose service always refuses, so that no test needs a schema. */
-  private val connection: IO[(Connection[IO], Queue[IO, Reply])] =
-    for
-      queue <- Queue.unbounded[IO, Reply]
-      conn  <- Connection[IO](_ => IO.none, queue)
-    yield (conn, queue)
+  private val connection: Resource[IO, (Connection[IO], Queue[IO, Reply])] =
+    BaseSuite.connectionResource(_ => IO.none)
 
   test("A Ping before ConnectionInit gets a Pong reply"):
-    connection.flatMap: (conn, queue) =>
+    connection.use: (conn, queue) =>
       conn.receive(FromClient.Ping()) *>
-        queue.take.assertEquals(FromServer.Pong().asRight.some)
+        queue.take.assertEquals(Reply.Send(FromServer.Pong()))
 
   test("A Ping with a payload gets a Pong reply without a payload"):
     val payload = JsonObject("seq" -> Json.fromInt(1))
-    connection.flatMap: (conn, queue) =>
+    connection.use: (conn, queue) =>
       conn.receive(FromClient.Ping(payload.some)) *>
-        queue.take.assertEquals(FromServer.Pong().asRight.some)
+        queue.take.assertEquals(Reply.Send(FromServer.Pong()))
 
   test("A Ping does not close the connection"):
-    connection.flatMap: (conn, queue) =>
+    connection.use: (conn, queue) =>
       for
         _ <- conn.receive(FromClient.Ping())
-        _ <- queue.take.assertEquals(FromServer.Pong().asRight.some)
+        _ <- queue.take.assertEquals(Reply.Send(FromServer.Pong()))
         _ <- conn.receive(FromClient.Ping())
-        _ <- queue.take.assertEquals(FromServer.Pong().asRight.some)
+        _ <- queue.take.assertEquals(Reply.Send(FromServer.Pong()))
       yield ()
 
   test("A Pong from the client gets no reply"):
-    connection.flatMap: (conn, queue) =>
+    connection.use: (conn, queue) =>
       conn.receive(FromClient.Pong()) *> queue.tryTake.assertEquals(None)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/DuplicateSubscriptionIdSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/DuplicateSubscriptionIdSuite.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import cats.syntax.all.*
+import clue.model.StreamingMessage.FromClient
+import clue.model.json.given
+import io.circe.parser.decode
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.otel4s.trace.Tracer
+
+import scala.concurrent.duration.*
+
+/**
+ * The graphql-transport-ws protocol reserves close code 4409 for a `subscribe` message that uses
+ * an id that is already active. This suite checks the path from the client message to the reply
+ * queue of the connection.
+ */
+final class DuplicateSubscriptionIdSuite extends CatsEffectSuite:
+
+  given Logger[IO] = BaseSuite.logger
+  given Tracer[IO] = Tracer.noop[IO]
+
+  private def fromClient(s: String): FromClient =
+    decode[FromClient](s).fold(throw _, identity)
+
+  private val init: FromClient =
+    fromClient("""{"type":"connection_init"}""")
+
+  // The `ticks` source stream never ends, so the subscription stays active.
+  private def subscribe(id: String): FromClient =
+    fromClient(s"""{"id":"$id","type":"subscribe","payload":{"query":"subscription { ticks }"}}""")
+
+  private def complete(id: String): FromClient =
+    fromClient(s"""{"id":"$id","type":"complete"}""")
+
+  // Sends the messages to an initialized connection on the virtual clock, then returns every
+  // reply that the connection made, after the messages settle.
+  private def repliesAfter(ms: FromClient*): IO[List[Reply]] =
+    TestControl.executeEmbed:
+      BaseSuite
+        .connectionResource(_ => GraphQLService(VariablesMapping).some.pure[IO])
+        .use: (conn, queue) =>
+          conn.receive(init) *>
+            ms.toList.traverse_(conn.receive) *>
+            IO.sleep(1.second) *>
+            queue.tryTakeN(none)
+
+  private val alreadyExists: Reply =
+    Reply.CloseWith(GraphQLWSError.SubscriberAlreadyExists("1"))
+
+  test("a second subscribe with an active id closes the socket with code 4409"):
+    repliesAfter(subscribe("1"), subscribe("1")).map: obt =>
+      assert(obt.contains(alreadyExists), s"expected a 4409 close request, got $obt")
+
+  test("a second subscribe with an active id ends the reply stream"):
+    repliesAfter(subscribe("1"), subscribe("1")).map: obt =>
+      assertEquals(obt.lastOption, alreadyExists.some, s"the close was not the last reply: $obt")
+
+  test("a message that arrives after the close is ignored"):
+    repliesAfter(subscribe("1"), subscribe("1"), complete("2"), subscribe("3"), init).map: obt =>
+      assertEquals(obt.lastOption, alreadyExists.some, s"the close was not the last reply: $obt")
+
+  test("a subscribe with a free id does not close the socket"):
+    repliesAfter(subscribe("1"), subscribe("2")).map: obt =>
+      assert(!obt.contains(alreadyExists), s"the second id closed the socket, got $obt")
+
+  test("an id is free again after the client sends complete"):
+    repliesAfter(subscribe("1"), complete("1"), subscribe("1")).map: obt =>
+      assert(!obt.contains(alreadyExists), s"the reused id closed the socket, got $obt")

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.graphql.routes
 
 import cats.effect.*
+import cats.effect.std.Supervisor
 import cats.effect.testkit.TestControl
 import cats.implicits.*
 import cats.~>
@@ -17,14 +18,9 @@ import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.*
 
-
 class SubscriptionsSuite extends CatsEffectSuite:
 
   given Logger[IO] = BaseSuite.logger
-
-  // Runs one test program on the virtual clock.
-  private def run(io: IO[Unit]): IO[Unit] =
-    TestControl.executeEmbed(io)
 
   private val settle: IO[Unit] =
     IO.sleep(1.second)
@@ -36,125 +32,180 @@ class SubscriptionsSuite extends CatsEffectSuite:
     case Complete(id)            => s"complete:$id"
     case other                   => other.toString
 
-  private def recorder: IO[(Ref[IO, List[String]], Option[FromServer] => IO[Unit])] =
-    Ref[IO].of(List.empty[String]).map: ref =>
-      (ref, msg => msg.fold(IO.unit)(m => ref.update(_ :+ label(m))))
+  private def recorder: IO[(Ref[IO, List[String]], FromServer => IO[Unit])] =
+    Ref[IO]
+      .of(List.empty[String])
+      .map(ref => (ref, msg => ref.update(_ :+ label(msg))))
 
   private val ok: Result[Json] = Result(Json.fromString("ok"))
 
   private def boom: Throwable = new RuntimeException("boom")
 
   private val delayingLogger: Logger[IO] =
-    BaseSuite.logger.mapK(new (IO ~> IO) { def apply[A](fa: IO[A]): IO[A] = IO.sleep(200.milliseconds) *> fa })
+    BaseSuite.logger.mapK(new (IO ~> IO):
+      def apply[A](fa: IO[A]): IO[A] = IO.sleep(200.milliseconds) *> fa)
+
+  // Runs one test program on the virtual clock, inside a Supervisor scope for the subscriptions.
+  // `log` reads the labels of the messages that the subscriptions sent so far.
+  private def run(io: (Subscriptions[IO], IO[List[String]]) => IO[Unit])(using Logger[IO]): IO[Unit] =
+    TestControl.executeEmbed:
+      Supervisor[IO].use: sup =>
+        for
+          (rec, send) <- recorder
+          subs        <- Subscriptions[IO](sup, send)
+          _           <- io(subs, rec.get)
+        yield ()
 
   test("a stream that ends before the map entry exists still produces a Complete"):
     given Logger[IO] = delayingLogger
-    run:
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        _           <- subs.add("1", Stream(ok).covary[IO])
-        _           <- settle
-        obt         <- log.get
+        _   <- subs.add("1", Stream(ok).covary[IO])
+        _   <- settle
+        obt <- log
       yield assertEquals(obt, List("next:1", "complete:1"))
 
   test("a cancelled add leaves no subscription that removeAll cannot stop"):
     given Logger[IO] = delayingLogger
-    run:
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        f           <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok)).start
-        _           <- IO.sleep(100.milliseconds)
-        _           <- f.cancel
-        _           <- subs.removeAll
-        obt         <- log.get
+        f   <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok)).start
+        _   <- IO.sleep(100.milliseconds)
+        _   <- f.cancel
+        _   <- subs.removeAll
+        obt <- log
       yield assertEquals(obt.count(_ === "complete:1"), 1)
 
   test("a stream that ends naturally produces one Complete after the results"):
-    run:
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        _           <- subs.add("1", Stream(ok, ok).covary[IO])
-        _           <- settle
-        obt         <- log.get
+        _   <- subs.add("1", Stream(ok, ok).covary[IO])
+        _   <- settle
+        obt <- log
       yield assertEquals(obt, List("next:1", "next:1", "complete:1"))
 
   test("a stream that fails sends an Error after the results, and no Complete"):
-    run:
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        _           <- subs.add("1", Stream(ok, ok).covary[IO] ++ Stream.raiseError[IO](boom))
-        _           <- settle
-        obt         <- log.get
+        _   <- subs.add("1", Stream(ok, ok).covary[IO] ++ Stream.raiseError[IO](boom))
+        _   <- settle
+        obt <- log
       yield assertEquals(obt, List("next:1", "next:1", "error:1"))
 
   test("a stream that fails before the map entry exists still produces an Error"):
     given Logger[IO] = delayingLogger
-    run:
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        _           <- subs.add("1", Stream.raiseError[IO](boom))
-        _           <- settle
+        _   <- subs.add("1", Stream.raiseError[IO](boom))
+        _   <- settle
         // A leaked entry would make one of these send a Complete for a dead subscription.
-        _           <- subs.remove("1")
-        _           <- subs.removeAll
-        _           <- settle
-        obt         <- log.get
+        _   <- subs.remove("1")
+        _   <- subs.removeAll
+        _   <- settle
+        obt <- log
       yield assertEquals(obt, List("error:1"))
 
-  test("no Complete follows an Error, because Error ends the operation"):
-    // `replySink` turns a Failure result into an Error message and the stream continues. The
-    // protocol makes Error terminal for an id, so the finalizer must not add a Complete.
-    run:
+  test("an Error ends the operation: no Next and no Complete follow it"):
+    // The protocol makes Error terminal for an id. The stream must end after the first Error
+    // message, even when the source stream has more results.
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        _           <- subs.add("1", Stream(Result.failure[Json]("boom"), ok).covary[IO])
-        _           <- settle
-        obt         <- log.get
-      yield assertEquals(obt, List("error:1", "next:1"))
+        _   <- subs.add("1", Stream(Result.failure[Json]("boom"), ok).covary[IO])
+        _   <- settle
+        obt <- log
+      yield assertEquals(obt, List("error:1"))
+
+  test("an id is free again as soon as an Error goes to the client"):
+    run: (subs, log) =>
+      for
+        _   <- subs.add("1", Stream(Result.failure[Json]("boom")).covary[IO].onFinalize(IO.sleep(1.second)))
+        _   <- IO.sleep(100.milliseconds)
+        res <- subs.add("1", Stream(ok).covary[IO])
+        _   <- settle
+        obt <- log
+      yield
+        assert(res, "the reused id did not start an event stream")
+        assertEquals(obt, List("error:1", "next:1", "complete:1"))
+
+  test("no Complete follows an Error when the caller removes the subscription"):
+    // The Error ends the stream and frees the id. A later `remove` must find nothing and must
+    // not send a Complete for the ended id.
+    run: (subs, log) =>
+      for
+        _   <- subs.add("1", Stream(Result.failure[Json]("boom")).covary[IO] ++ Stream.never[IO])
+        _   <- IO.sleep(100.milliseconds)
+        _   <- subs.remove("1")
+        _   <- settle
+        obt <- log
+      yield assertEquals(obt, List("error:1"))
+
+  test("no Complete follows an Error when removeAll stops the subscription"):
+    run: (subs, log) =>
+      for
+        _   <- subs.add("1", Stream(Result.failure[Json]("boom")).covary[IO] ++ Stream.never[IO])
+        _   <- IO.sleep(100.milliseconds)
+        _   <- subs.removeAll
+        _   <- settle
+        obt <- log
+      yield assertEquals(obt, List("error:1"))
 
   test("remove on a running subscription produces exactly one Complete"):
-    run:
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        _           <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok))
-        _           <- IO.sleep(100.milliseconds)
-        _           <- subs.remove("1")
-        _           <- settle
-        obt         <- log.get
+        _   <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok))
+        _   <- IO.sleep(100.milliseconds)
+        _   <- subs.remove("1")
+        _   <- settle
+        obt <- log
       yield
         assert(obt.count(_ === "next:1") >= 1, "the stream sent nothing before remove")
         assertEquals(obt.count(_ === "complete:1"), 1)
 
-  test("the finalizer of a replaced subscription does not remove the live entry"):
-    // A duplicate id replaces the map entry. When the replaced stream ends, its finalizer must
-    // leave the new entry alone, so that removeAll can still cancel the new fiber.
-    run:
+  test("a subscribe with an id that is active reports a duplicate and sends nothing"):
+    run: (subs, log) =>
       for
-        (log, send) <- recorder
-        subs        <- Subscriptions[IO](send)
-        ticks       <- Ref[IO].of(0)
-        release     <- Deferred[IO, Unit]
-        // Ends only when the test completes `release`.
-        _           <- subs.add("1", Stream.eval(release.get).drain)
-        // Replaces the entry for id "1" in the map.
-        _           <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).evalTap(_ => ticks.update(_ + 1)).as(ok))
-        _           <- IO.sleep(100.milliseconds)
-        _           <- release.complete(())
-        _           <- IO.sleep(100.milliseconds)
-        _           <- subs.removeAll
-        _           <- IO.sleep(100.milliseconds)
-        before      <- ticks.get
-        _           <- settle
-        after       <- ticks.get
-        obt         <- log.get
+        _   <- subs.add("1", Stream.never[IO])
+        res <- subs.add("1", Stream(ok).covary[IO])
+        _   <- settle
+        obt <- log
       yield
-        assert(before >= 1, "the live stream sent nothing before removeAll")
-        assertEquals(after, before, "the fiber of the live subscription outlived removeAll")
+        assert(!res, "the duplicate id started an event stream")
+        assertEquals(obt, Nil)
+
+  test("a duplicate subscribe does not cancel or replace the active subscription"):
+    run: (subs, log) =>
+      for
+        _      <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok))
+        _      <- IO.sleep(100.milliseconds)
+        // The duplicate stream would send an Error if it started.
+        _      <- subs.add("1", Stream(Result.failure[Json]("dup")).covary[IO])
+        before <- log.map(_.count(_ === "next:1"))
+        _      <- IO.sleep(100.milliseconds)
+        after  <- log.map(_.count(_ === "next:1"))
+        _      <- subs.removeAll
+        _      <- settle
+        obt    <- log
+      yield
+        assert(after > before, "the duplicate subscribe stopped the active stream")
+        assert(!obt.contains("error:1"), "the duplicate stream started")
         assertEquals(obt.count(_ === "complete:1"), 1)
+
+  test("an id is free again after its stream ends"):
+    run: (subs, log) =>
+      for
+        _   <- subs.add("1", Stream(ok).covary[IO])
+        _   <- settle
+        _   <- subs.add("1", Stream(ok).covary[IO])
+        _   <- settle
+        obt <- log
+      yield assertEquals(obt, List("next:1", "complete:1", "next:1", "complete:1"))
+
+  test("an id is free again after remove"):
+    run: (subs, _) =>
+      for
+        _   <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok))
+        _   <- IO.sleep(100.milliseconds)
+        _   <- subs.remove("1")
+        res <- subs.add("1", Stream(ok).covary[IO])
+        _   <- settle
+      yield assert(res, "the id was not free after remove")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("edu.gemini"       % "sbt-lucuma-lib" % "0.14.20")
+addSbtPlugin("edu.gemini" % "sbt-lucuma-lib" % "0.14.20")


### PR DESCRIPTION
A `Supervisor` now owns every subscription fiber, and the socket stream owns the supervisor. When the socket closes, the runtime cancels each fiber. Before this change, fibers outlived the connection.

The server now follows the graphql-ws protocol in three cases:

1. A `subscribe` message with an id that is already active closes the socket with code 4409. Before, the server dropped the old map entry and left its fiber alive, and that fiber sent `next` messages with the same id.
2. An `error` message ends the subscription. The stream stops after the first `error`, and the id leaves the map. No `next` and no `complete` follow an `error`, and the client can reuse the id.
3. The reply stream ends after a terminal reply, which stops the keepalive stream. No `ping` follows the close frame.

A new `Reply` type replaces `Option[Either[GraphQLWSError, FromServer]]` on the reply queue. The three cases `Send`, `CloseWith` and `End` state which replies end the connection.

A closed connection now ignores each late client message. Before, it raised an error, which failed the socket before the close frame reached the client. The client then saw an abnormal close without a code.

Tests cover the duplicate id, the terminal `error`, and the fiber cleanup.
