### PR TITLE
Return correct status codes and bodies for execution and internal errors

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Routes.scala
@@ -73,10 +73,21 @@ object Routes {
     object VariablesMatcher     extends OptionalValidatingQueryParamDecoderMatcher[JsonObject]("variables")(using jsonObjectDecoder("variables"))
     object ExtensionsMatcher    extends OptionalValidatingQueryParamDecoderMatcher[JsonObject]("extensions")(using jsonObjectDecoder("extensions"))
 
+    // The specification requires a well-formed GraphQL response body for the GraphQL media type at
+    // every status. An unexpected error gives status 500 with a generic message and no data. The
+    // cause goes to the log, not to the client.
+    def internalErrorResponse(t: ResponseMediaType)(err: Throwable): F[Response[F]] =
+      Logger[F].error(err)("Internal error in GraphQL request handling.") *>
+        t.errorResponse[F](InternalServerError, "Internal server error.").pure[F]
+
     // Select the media type of the response. The specification requires status 406 when the
-    // server supports no media type that the client accepts.
+    // server supports no media type that the client accepts. This is the error boundary of every
+    // HTTP GraphQL route, because it is the first point that knows the media type of the response.
     def negotiated(req: Request[F])(use: ResponseMediaType => F[Response[F]]): F[Response[F]] =
-      ResponseMediaType.negotiateOrError(req.headers).fold(NotAcceptable(_), use)
+      ResponseMediaType.negotiateOrError(req.headers).fold(
+        NotAcceptable(_),
+        t => use(t).handleErrorWith(internalErrorResponse(t))
+      )
 
     // Select the response media type, then build a handler for the authorized service.
     def withHandler(req: Request[F])(use: HttpRouteHandler[F] => F[Response[F]]): F[Response[F]] =
@@ -163,8 +174,9 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](
       case _                    => failureStatus
     }
 
-  // Builds the response for a result. `mkResponse` raises the error of an internal error, which
-  // http4s turns into status 500.
+  // Builds the response for a result. `mkResponse` raises the error of an internal error. The
+  // route boundary in `Routes.forService` turns that error into status 500 with a GraphQL error
+  // body.
   def toResponse(result: Result[Json], failureStatus: Status = UnprocessableContent): F[Response[F]] =
     service.mapping.mkResponse(result).flatMap(respond(statusFor(result, failureStatus), _))
 
@@ -198,15 +210,25 @@ class HttpRouteHandler[F[_]: {Temporal, Tracer}](
       "Mutation operations are not supported on a GET request. Use a POST request."
     ).map(_.putHeaders(Allow(Method.POST)))
 
+  // The specification treats an error that execution raises as a field error. The response to a
+  // field error must have a `data` entry and a 2xx status. A bare failure carries no value, so
+  // this handler gives it the value `null` and lets `toResponse` select the 2xx status.
+  private def executionResponse(result: Result[Json]): F[Response[F]] =
+    toResponse(result match {
+      case Result.Failure(problems) => Result.Warning(problems, Json.Null)
+      case other                    => other
+    })
+
   // Runs the operation and builds the response. A failure of the parse stage carries no
-  // operation, so its status comes from the document instead of from the execution stage.
+  // operation, so its status comes from the document. A failure of the execution stage is a
+  // field error, which gives a 2xx status with a null `data` entry.
   private def execute(
     parsed:   Result[Operation],
     document: String
   )(run: Operation => F[Result[Json]]): F[Response[F]] =
     parsed match {
       case f: Result.Failure => toResponse(f, parseFailureStatus(document))
-      case _                 => parsed.flatTraverse(run).flatMap(toResponse(_))
+      case _                 => parsed.flatTraverse(run).flatMap(executionResponse)
     }
 
   // If the parsed operation is a subscription, return a 422 rejection immediately.

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ResponseStatusSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ResponseStatusSuite.scala
@@ -5,6 +5,8 @@ package lucuma.graphql.routes
 
 import cats.effect.*
 import cats.implicits.*
+import grackle.Cursor
+import grackle.Query
 import grackle.Result
 import grackle.circe.CirceMapping
 import grackle.syntax.*
@@ -19,20 +21,39 @@ import org.typelevel.ci.*
 //   ping         - a plain success
 //   nullableFail - a field error on a nullable field
 //   nonNullFail  - a field error on a non-null field
+//   effectFail   - an effect handler failure, which aborts execution with a bare
+//                  `Result.Failure` that carries no data
+//   internalFail - an internal error result, which `mkResponse` raises as an exception
+//   effectThrow  - an effect handler that raises an exception in `F`
 object ResponseStatusMapping extends CirceMapping[IO]:
   val schema = schema"""
     type Query {
       ping: String!
       nullableFail: String
       nonNullFail: String!
+      effectFail: String!
+      internalFail: String!
+      effectThrow: String!
     }
   """
   val QueryType    = schema.ref("Query")
+
+  private val failingHandler = new Query.EffectHandler[IO]:
+    def runEffects(queries: List[(Query, Cursor)]): IO[Result[List[Cursor]]] =
+      Result.failure[List[Cursor]]("effect boom").pure[IO]
+
+  private val throwingHandler = new Query.EffectHandler[IO]:
+    def runEffects(queries: List[(Query, Cursor)]): IO[Result[List[Cursor]]] =
+      IO.raiseError(new RuntimeException("secret effect detail"))
+
   val typeMappings = TypeMappings.unchecked(
     ObjectMapping(QueryType)(
       CursorFieldJson("ping", _ => Result.success(Json.fromString("pong")), Nil),
       CursorFieldJson("nullableFail", _ => Result.failure("nullable boom"), Nil),
-      CursorFieldJson("nonNullFail", _ => Result.failure("non-null boom"), Nil)
+      CursorFieldJson("nonNullFail", _ => Result.failure("non-null boom"), Nil),
+      EffectField("effectFail", failingHandler, Nil),
+      CursorFieldJson("internalFail", _ => Result.internalError(new RuntimeException("secret internal detail")), Nil),
+      EffectField("effectThrow", throwingHandler, Nil)
     )
   )
 
@@ -46,11 +67,18 @@ class ResponseStatusSuite extends BaseSuite:
   // These tests are about the status of a modern client, so they ask for the GraphQL media type.
   private val AcceptGraphQL = Header.Raw(ci"Accept", "application/graphql-response+json")
 
-  private def post(query: String, operationName: Option[String] = None): IO[(Status, Json)] =
+  // A legacy client asks for `application/json`, so it never gets status 294.
+  private val AcceptJson = Header.Raw(ci"Accept", "application/json")
+
+  private def post(
+    query:         String,
+    operationName: Option[String] = None,
+    accept:        Header.Raw = AcceptGraphQL
+  ): IO[(Status, Json)] =
     rawResponse: uri =>
       val fields = List("query" -> Json.fromString(query)) ++
         operationName.map(n => "operationName" -> Json.fromString(n))
-      Request[IO](Method.POST, uri).withEntity(Json.fromFields(fields)).putHeaders(AcceptGraphQL)
+      Request[IO](Method.POST, uri).withEntity(Json.fromFields(fields)).putHeaders(accept)
     .map((status, _, body) => (status, parser.parse(body).getOrElse(Json.Null)))
 
   private def get(query: String): IO[(Status, Json)] =
@@ -63,6 +91,10 @@ class ResponseStatusSuite extends BaseSuite:
 
   private def hasData(body: Json): Boolean =
     body.hcursor.downField("data").succeeded
+
+  // The `data` entry is present and null. The specification requires this entry for a field error.
+  private def hasNullData(body: Json): Boolean =
+    body.hcursor.downField("data").as[Option[Json]] == Right(None)
 
   // --- success ----------------------------------------------------------------
 
@@ -79,13 +111,13 @@ class ResponseStatusSuite extends BaseSuite:
   test("a field error on a nullable field returns 294 with a null data entry"):
     post("query { nullableFail }").map: (status, body) =>
       assertEquals(status.code, 294)
-      assertEquals(body.hcursor.downField("data").as[Option[Json]], Right(None))
+      assert(hasNullData(body), body.spaces2)
       assert(hasErrors(body), body.spaces2)
 
   test("a field error on a non-null field returns 294 with a null data entry"):
     post("query { nonNullFail }").map: (status, body) =>
       assertEquals(status.code, 294)
-      assertEquals(body.hcursor.downField("data").as[Option[Json]], Right(None))
+      assert(hasNullData(body), body.spaces2)
       assert(hasErrors(body), body.spaces2)
 
   // A field error next to a field that succeeds still gives status 294.
@@ -104,7 +136,7 @@ class ResponseStatusSuite extends BaseSuite:
     rawResponse: uri =>
       Request[IO](Method.POST, uri)
         .withEntity(Json.obj("query" -> Json.fromString("query { nullableFail }")))
-        .putHeaders(Header.Raw(ci"Accept", "application/json"))
+        .putHeaders(AcceptJson)
     .map: (status, headers, text) =>
       val body = parser.parse(text).getOrElse(Json.Null)
       assertEquals(status, Status.Ok)
@@ -122,6 +154,64 @@ class ResponseStatusSuite extends BaseSuite:
       assert(hasErrors(parser.parse(text).getOrElse(Json.Null)))
       val contentType = headers.get(ci"Content-Type").map(_.head.value)
       assert(contentType.exists(_.startsWith("application/json")), s"Got: $contentType")
+
+  // An effect handler failure aborts execution, so grackle returns a `Result.Failure` with no
+  // data. The error comes from execution, so the specification treats it as a field error: the
+  // response must have a `data` entry, which is null, and a 2xx status.
+  test("an effect handler failure returns 294 with a null data entry"):
+    post("query { effectFail }").map: (status, body) =>
+      assertEquals(status.code, 294)
+      assert(hasNullData(body), body.spaces2)
+      assert(hasErrors(body), body.spaces2)
+
+  test("a legacy client gets 200 with a null data entry for an effect handler failure"):
+    post("query { effectFail }", accept = AcceptJson).map: (status, body) =>
+      assertEquals(status, Status.Ok)
+      assert(hasNullData(body), body.spaces2)
+      assert(hasErrors(body), body.spaces2)
+
+  test("GET of an effect handler failure returns 294 with a null data entry"):
+    get("query { effectFail }").map: (status, body) =>
+      assertEquals(status.code, 294)
+      assert(hasNullData(body), body.spaces2)
+      assert(hasErrors(body), body.spaces2)
+
+  // --- internal errors --------------------------------------------------------
+
+  // The specification requires a well-formed GraphQL response body for the GraphQL media type at
+  // every status. An unexpected server error gives status 500 with an `errors` entry, a generic
+  // message, and no `data` entry.
+  test("an internal error returns 500 with a GraphQL error body"):
+    rawResponse: uri =>
+      Request[IO](Method.POST, uri)
+        .withEntity(Json.obj("query" -> Json.fromString("query { internalFail }")))
+        .putHeaders(AcceptGraphQL)
+    .map: (status, headers, text) =>
+      val body = parser.parse(text).getOrElse(Json.Null)
+      assertEquals(status, Status.InternalServerError)
+      assert(hasErrors(body), text)
+      assert(!hasData(body), text)
+      assert(!text.contains("secret internal detail"), text)
+      val contentType = headers.get(ci"Content-Type").map(_.head.value)
+      assert(contentType.exists(_.startsWith("application/graphql-response+json")), s"Got: $contentType")
+
+  test("an exception raised by an effect handler returns 500 with a GraphQL error body"):
+    post("query { effectThrow }").map: (status, body) =>
+      assertEquals(status, Status.InternalServerError)
+      assert(hasErrors(body), body.spaces2)
+      assert(!hasData(body), body.spaces2)
+      assert(!body.spaces2.contains("secret effect detail"), body.spaces2)
+
+  test("a legacy client gets a GraphQL error body for an internal error"):
+    post("query { internalFail }", accept = AcceptJson).map: (status, body) =>
+      assertEquals(status, Status.InternalServerError)
+      assert(hasErrors(body), body.spaces2)
+
+  test("GET of an internal error returns 500 with a GraphQL error body"):
+    get("query { internalFail }").map: (status, body) =>
+      assertEquals(status, Status.InternalServerError)
+      assert(hasErrors(body), body.spaces2)
+      assert(!hasData(body), body.spaces2)
 
   // --- request errors ---------------------------------------------------------
 
@@ -153,8 +243,9 @@ class ResponseStatusSuite extends BaseSuite:
 
   // --- a result without data --------------------------------------------------
 
-  // Grackle keeps the `data` entry for a field error, so a response without `data` comes from a
-  // result that carries no value. The specification forbids a 2xx status for such a response.
+  // A result that carries no value comes from the parse stage, because the handler gives an
+  // execution failure the value `null`. The specification forbids a 2xx status for a response
+  // without a `data` entry.
   test("a result without a value returns 422"):
     new HttpRouteHandler(GraphQLService(ResponseStatusMapping), ResponseMediaType.GraphQL)
       .toResponse(Result.failure[Json]("boom"))


### PR DESCRIPTION
An unexpected server error gave a plain 500 response with no GraphQL body. The specification requires a well-formed GraphQL response body at every status. The handler now catches the error, logs the cause, and returns status 500 with a generic message. The cause does not go to the client.

An error that execution raises is a field error. The specification requires a `data` entry and a 2xx status for a field error. Grackle omits the `data` entry of a failure result, so the handler adds `"data": null` when the entry is absent.

Tests cover an internal error result, an exception from an effect handler, and an effect handler failure. Each case runs over GET and POST, and over both the GraphQL media type and the legacy `application/json` media type.
