### PR TITLE
Run queries and mutations as cancelable operations

### DIFF
--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -15,8 +15,11 @@ import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.*
 import clue.model.StreamingMessage.FromClient.*
 import clue.model.StreamingMessage.FromServer.*
+import fs2.Stream
 import grackle.Operation
+import grackle.Result
 import grackle.Result.*
+import io.circe.Json
 import io.circe.JsonObject
 import org.http4s.ParseResult
 import org.http4s.headers.Authorization
@@ -68,7 +71,7 @@ object Connection {
     def start(id:  String, req: GraphQLRequest[JsonObject]): (ConnectionState[F], F[Option[GraphQLWSError]])
 
     /**
-     * Terminates a Graph QL subscription associated with a particular id
+     * Stops the GraphQL operation associated with a particular id
      * @return state transition and action to execute
      */
     def stop(id: String): (ConnectionState[F], F[Unit])
@@ -146,9 +149,13 @@ object Connection {
         val document    = raw.query.value
         val parseResult = service.parse(document, raw.operationName, raw.variables)
         val name        = raw.operationName
+        // A subscription is its own event stream; a query or mutation is a one-element stream.
+        def events(op: Operation): Stream[F, Result[Json]] =
+          if (service.isSubscription(op)) service.subscribe(op, document, name)
+          else Stream.eval(service.query(op, document, name))
         val action = parseResult match {
-          case Success(op)        => if (service.isSubscription(op)) subscribe(id, op, document, name) else execute(id, op, document, name)
-          case Warning(_, op)     => if (service.isSubscription(op)) subscribe(id, op, document, name) else execute(id, op, document, name) // n.b. warnings on subscribe are lost
+          case Success(op)        => startOperation(id, events(op))
+          case Warning(_, op)     => startOperation(id, events(op)) // n.b. warnings on start are lost
           case Failure(ps)        => send(Reply.Send(Error(id, mkGraphqlErrors(ps)))).as(none)
           case InternalError(err) => send(Reply.Send(Error(id, mkGraphqlErrors(err)))).as(none)
         }
@@ -167,31 +174,13 @@ object Connection {
             span.addAttributes(service.props*) >>
             fa
 
-      // The protocol reserves close code 4409 for a `subscribe` message that uses an id that is
-      // already active. The subscription map reports the duplicate and the connection closes.
-      def subscribe(
-        id:            String,
-        request:       Operation,
-        document:      String,
-        operationName: Option[String]
-      ): F[Option[GraphQLWSError]] =
+      // Every operation runs as an event stream in the subscription map, so a slow operation
+      // does not block the receive loop and a client `complete` message can cancel it. The
+      // protocol reserves close code 4409 for an id that is already active.
+      def startOperation(id: String, events: Stream[F, Result[Json]]): F[Option[GraphQLWSError]] =
         inOperationSpan(id):
-          subscriptions.add(id, service.subscribe(request, document, operationName)).map: added =>
+          subscriptions.add(id, events).map: added =>
             Option.unless(added)(GraphQLWSError.SubscriberAlreadyExists(id))
-
-      def execute(
-        id:            String,
-        request:       Operation,
-        document:      String,
-        operationName: Option[String]
-      ): F[Option[GraphQLWSError]] =
-        inOperationSpan(id):
-          service.query(request, document, operationName).flatMap { r =>
-            mkFromServer(r, id).flatMap {
-              case Right(data) => send(Reply.Send(data)) *> send(Reply.Send(FromServer.Complete(id)))
-              case Left(error) => send(Reply.Send(error))
-            }
-          }.as(none)
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
         (closed, subscriptions.removeAll *> send(lastReply(reason)))

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Subscriptions.scala
@@ -20,15 +20,16 @@ import grackle.Result
 import io.circe.Json
 import org.typelevel.log4cats.Logger
 
-/** A GraphQL subscription in effect type F. */
+/** The active GraphQL operations of a connection, in effect type F. */
 trait Subscriptions[F[_]] {
 
   /**
-   * Adds a new subscription receiving events from the provided `Stream`.
+   * Adds a new operation receiving events from the provided `Stream`. A query or mutation is a
+   * one-element stream.
    * @param id
-   *   client-provided id for the subscription
+   *   client-provided id for the operation
    * @param events
-   *   stream of Either errors or Json results that match the subscription query
+   *   stream of Either errors or Json results that the operation produces
    * @return
    *   true if the event stream started, false if the id is already in use. The caller decides what
    *   a duplicate id means for the connection.
@@ -36,13 +37,13 @@ trait Subscriptions[F[_]] {
   def add(id: String, events: Stream[F, Result[Json]]): F[Boolean]
 
   /**
-   * Removes a subscription so that it no longer provides events to the client.
+   * Removes an operation so that it no longer provides events to the client.
    * @param id
    *   client-provided id
    */
   def remove(id: String): F[Unit]
 
-  /** Removes all subscriptions. */
+  /** Removes all operations. */
   def removeAll: F[Unit]
 
 }
@@ -50,9 +51,9 @@ trait Subscriptions[F[_]] {
 object Subscriptions {
 
   /**
-   * Tracks a single client subscription.
+   * Tracks a single client operation.
    * @param fiber
-   *   Holds the fiber of the event stream once the map entry for the subscription exists. The event
+   *   Holds the fiber of the event stream once the map entry for the operation exists. The event
    *   stream waits for it, so the stream cannot end before the entry that its finalizer must clean
    *   up exists.
    * @param errorSent
@@ -72,14 +73,23 @@ object Subscriptions {
 
     Ref[F].of(Map.empty[String, Subscription[F]]).map { subscriptions =>
       new Subscriptions[F]() {
-        // The caller that takes an entry out of the map owns the `Complete` for that id, unless
-        // an `error` message already went to the client.
-        private def stopAndComplete(id: String, s: Subscription[F]): F[Unit] =
-          (s.stop *> s.errorSent.get.flatMap(err => send(Complete(id)).unlessA(err)))
-            .handleErrorWith(t => Logger[F].warn(t)(s"could not remove subscription $id"))
 
         /**
-         * Inserts a new subscription and starts its event stream. If the id is already in use, the
+         * Cancels the subscription without sending a terminal message to the client.
+         */
+        private def stopOnly(id: String, s: Subscription[F]): F[Unit] =
+          s.stop.handleErrorWith(t => Logger[F].warn(t)(s"could not remove operation $id"))
+
+        /**
+         * Cancels the subscription and sends a terminal message to the client, unless an `error`
+         * message already went to the client.
+         */
+        private def stopAndComplete(id: String, s: Subscription[F]): F[Unit] =
+          (s.stop *> s.errorSent.get.flatMap(err => send(Complete(id)).unlessA(err)))
+            .handleErrorWith(t => Logger[F].warn(t)(s"could not remove operation $id"))
+
+        /**
+         * Inserts a new operation and starts its event stream. If the id is already in use, the
          * stream does not start and the map does not change.
          */
         private def insertAndStart(
@@ -91,7 +101,7 @@ object Subscriptions {
             if (m.contains(id))
               (
                 m,
-                Logger[F].debug(s"duplicate subscription id $id").as(false)
+                Logger[F].debug(s"duplicate operation id $id").as(false)
               )
             else
               (m.updated(id, entry),
@@ -138,7 +148,7 @@ object Subscriptions {
                              yield ()
             // The stream waits for its own fiber, so it cannot end before its map entry
             // exists. A natural end sends `complete` and a failure sends a terminal `error`.
-            // Cancellation sends nothing, because the canceller owns the `complete` for the id.
+            // Cancellation sends nothing, because the canceller decides what the client gets.
             subscription = (Stream.exec(fiberD.get.void) ++
                              events.through(replySink(id, errorSent, removeOwn)))
                              .onFinalizeCase {
@@ -151,9 +161,13 @@ object Subscriptions {
             result      <- insertAndStart(id, entry, subscription)
           } yield result).uncancelable
 
+        // A client `complete` message ends the operation. The client already stopped listening,
+        // so the server must not send a `complete` back for that id. The client can reuse the id
+        // as soon as it sent the message, and a late `complete` would end the operation that
+        // reuses it.
         override def remove(id: String): F[Unit] =
           subscriptions.flatModifyFull: (poll, s) =>
-            (s.removed(id), s.get(id).traverse_(sub => poll(stopAndComplete(id, sub))))
+            (s.removed(id), s.get(id).traverse_(sub => poll(stopOnly(id, sub))))
 
         override def removeAll: F[Unit] =
           subscriptions.flatModifyFull: (poll, s) =>

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionSuite.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import cats.syntax.all.*
+import clue.model.StreamingMessage.FromClient
+import clue.model.json.given
+import io.circe.parser.decode
+import munit.CatsEffectSuite
+import org.typelevel.log4cats.Logger
+import org.typelevel.otel4s.trace.Tracer
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * A suite that sends client messages to an in-process connection on the virtual clock, and asserts
+ * on the replies. There is no socket and no server.
+ */
+abstract class ConnectionSuite extends CatsEffectSuite:
+
+  given Logger[IO] = BaseSuite.logger
+  given Tracer[IO] = Tracer.noop[IO]
+
+  /** Decodes a client message from its wire format. */
+  protected def fromClient(s: String): FromClient =
+    decode[FromClient](s).fold(throw _, identity)
+
+  protected val init: FromClient = FromClient.ConnectionInit()
+
+  protected val ping: FromClient = FromClient.Ping()
+
+  protected def complete(id: String): FromClient = FromClient.Complete(id)
+
+  // Runs the script against an initialized connection on the virtual clock, then returns every
+  // reply that the connection made, after the given settle time. A script can sleep between
+  // messages, so a test can put a client message after the result of an operation.
+  protected def repliesOf(
+    settle: FiniteDuration
+  )(script: Connection[IO] => IO[Unit]): IO[List[Reply]] =
+    TestControl.executeEmbed:
+      BaseSuite
+        .connectionResource(_ => GraphQLService(TestMapping).some.pure[IO])
+        .use: (conn, queue) =>
+          conn.receive(init) *>
+            script(conn) *>
+            IO.sleep(settle) *>
+            queue.tryTakeN(none)
+
+  // Sends the messages to an initialized connection on the virtual clock, then returns every
+  // reply that the connection made, after the given settle time.
+  protected def repliesAfter(settle: FiniteDuration)(ms: FromClient*): IO[List[Reply]] =
+    repliesOf(settle)(conn => ms.toList.traverse_(conn.receive))

--- a/modules/core/src/test/scala/lucuma/graphql/routes/DuplicateSubscriptionIdSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/DuplicateSubscriptionIdSuite.scala
@@ -4,14 +4,8 @@
 package lucuma.graphql.routes
 
 import cats.effect.IO
-import cats.effect.testkit.TestControl
 import cats.syntax.all.*
 import clue.model.StreamingMessage.FromClient
-import clue.model.json.given
-import io.circe.parser.decode
-import munit.CatsEffectSuite
-import org.typelevel.log4cats.Logger
-import org.typelevel.otel4s.trace.Tracer
 
 import scala.concurrent.duration.*
 
@@ -20,55 +14,34 @@ import scala.concurrent.duration.*
  * an id that is already active. This suite checks the path from the client message to the reply
  * queue of the connection.
  */
-final class DuplicateSubscriptionIdSuite extends CatsEffectSuite:
-
-  given Logger[IO] = BaseSuite.logger
-  given Tracer[IO] = Tracer.noop[IO]
-
-  private def fromClient(s: String): FromClient =
-    decode[FromClient](s).fold(throw _, identity)
-
-  private val init: FromClient =
-    fromClient("""{"type":"connection_init"}""")
+final class DuplicateSubscriptionIdSuite extends ConnectionSuite:
 
   // The `ticks` source stream never ends, so the subscription stays active.
   private def subscribe(id: String): FromClient =
     fromClient(s"""{"id":"$id","type":"subscribe","payload":{"query":"subscription { ticks }"}}""")
 
-  private def complete(id: String): FromClient =
-    fromClient(s"""{"id":"$id","type":"complete"}""")
-
-  // Sends the messages to an initialized connection on the virtual clock, then returns every
-  // reply that the connection made, after the messages settle.
-  private def repliesAfter(ms: FromClient*): IO[List[Reply]] =
-    TestControl.executeEmbed:
-      BaseSuite
-        .connectionResource(_ => GraphQLService(VariablesMapping).some.pure[IO])
-        .use: (conn, queue) =>
-          conn.receive(init) *>
-            ms.toList.traverse_(conn.receive) *>
-            IO.sleep(1.second) *>
-            queue.tryTakeN(none)
+  private def replies(ms: FromClient*): IO[List[Reply]] =
+    repliesAfter(1.second)(ms*)
 
   private val alreadyExists: Reply =
     Reply.CloseWith(GraphQLWSError.SubscriberAlreadyExists("1"))
 
   test("a second subscribe with an active id closes the socket with code 4409"):
-    repliesAfter(subscribe("1"), subscribe("1")).map: obt =>
+    replies(subscribe("1"), subscribe("1")).map: obt =>
       assert(obt.contains(alreadyExists), s"expected a 4409 close request, got $obt")
 
   test("a second subscribe with an active id ends the reply stream"):
-    repliesAfter(subscribe("1"), subscribe("1")).map: obt =>
+    replies(subscribe("1"), subscribe("1")).map: obt =>
       assertEquals(obt.lastOption, alreadyExists.some, s"the close was not the last reply: $obt")
 
   test("a message that arrives after the close is ignored"):
-    repliesAfter(subscribe("1"), subscribe("1"), complete("2"), subscribe("3"), init).map: obt =>
+    replies(subscribe("1"), subscribe("1"), complete("2"), subscribe("3"), init).map: obt =>
       assertEquals(obt.lastOption, alreadyExists.some, s"the close was not the last reply: $obt")
 
   test("a subscribe with a free id does not close the socket"):
-    repliesAfter(subscribe("1"), subscribe("2")).map: obt =>
+    replies(subscribe("1"), subscribe("2")).map: obt =>
       assert(!obt.contains(alreadyExists), s"the second id closed the socket, got $obt")
 
   test("an id is free again after the client sends complete"):
-    repliesAfter(subscribe("1"), complete("1"), subscribe("1")).map: obt =>
+    replies(subscribe("1"), complete("1"), subscribe("1")).map: obt =>
       assert(!obt.contains(alreadyExists), s"the reused id closed the socket, got $obt")

--- a/modules/core/src/test/scala/lucuma/graphql/routes/OperationCancelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/OperationCancelSuite.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.IO
+import clue.model.StreamingMessage.FromClient
+import clue.model.StreamingMessage.FromServer
+
+import scala.concurrent.duration.*
+
+/**
+ * The graphql-transport-ws protocol lets a client run more than one operation at a time, and a
+ * client `complete` message stops the operation with that id. This holds for single result
+ * operations too: the server must not send the result after the client sent `complete`. This
+ * suite checks queries and mutations on the virtual clock; `slow` and `slowUpdate` produce one
+ * result after 10 seconds.
+ */
+final class OperationCancelSuite extends ConnectionSuite:
+
+  private def slowQuery(id: String): FromClient =
+    fromClient(s"""{"id":"$id","type":"subscribe","payload":{"query":"query { slow }"}}""")
+
+  private def slowMutation(id: String): FromClient =
+    fromClient(s"""{"id":"$id","type":"subscribe","payload":{"query":"mutation { slowUpdate }"}}""")
+
+  // The settle time gives every started operation time to finish.
+  private def replies(ms: FromClient*): IO[List[Reply]] =
+    repliesAfter(1.hour)(ms*)
+
+  private def isNext(id: String)(r: Reply): Boolean = r match
+    case Reply.Send(FromServer.Next(`id`, _)) => true
+    case _                                    => false
+
+  private def isPong(r: Reply): Boolean = r match
+    case Reply.Send(FromServer.Pong(_)) => true
+    case _                              => false
+
+  private def isError(id: String)(r: Reply): Boolean = r match
+    case Reply.Send(FromServer.Error(`id`, _)) => true
+    case _                                     => false
+
+  private def countComplete(id: String)(rs: List[Reply]): Int =
+    rs.count(_ == Reply.Send(FromServer.Complete(id)))
+
+  // Every message that carries an operation id: `next`, `error` and `complete`.
+  private def hasId(id: String)(r: Reply): Boolean = r match
+    case Reply.Send(FromServer.Next(`id`, _))  => true
+    case Reply.Send(FromServer.Error(`id`, _)) => true
+    case Reply.Send(FromServer.Complete(`id`)) => true
+    case _                                     => false
+
+  // The client stopped listening, so the server sends nothing at all for the id: no result and
+  // no `complete` either.
+  test("a client complete cancels a running query and sends nothing for its id"):
+    replies(slowQuery("1"), complete("1")).map: obt =>
+      assert(!obt.exists(hasId("1")), s"expected no message for the canceled query, got $obt")
+
+  test("a client complete cancels a running mutation and sends nothing for its id"):
+    replies(slowMutation("1"), complete("1")).map: obt =>
+      assert(!obt.exists(hasId("1")), s"expected no message for the canceled mutation, got $obt")
+
+  test("a slow query does not block messages that arrive after it"):
+    replies(slowQuery("1"), ping).map: obt =>
+      val pong = obt.indexWhere(isPong)
+      val next = obt.indexWhere(isNext("1"))
+      assert(pong >= 0 && next >= 0 && pong < next, s"expected pong before the query result, got $obt")
+
+  test("a query that runs to the end sends its result and then complete"):
+    replies(slowQuery("1")).map: obt =>
+      val next = obt.indexWhere(isNext("1"))
+      val comp = obt.indexOf(Reply.Send(FromServer.Complete("1")))
+      assert(next >= 0 && next < comp, s"expected a result and then complete, got $obt")
+
+  test("the id of a canceled query is free for reuse"):
+    replies(slowQuery("1"), complete("1"), slowQuery("1")).map: obt =>
+      assert(!obt.exists(_.isTerminal), s"the reused id closed the socket, got $obt")
+      assertEquals(obt.count(isNext("1")), 1, s"expected one result for the second query, got $obt")
+      // Only the second query completes. A `complete` from the cancel would end the second
+      // query on the client before its result arrived.
+      assertEquals(countComplete("1")(obt), 1, s"expected one complete for id 1, got $obt")
+
+  test("a client complete that arrives after the query finished changes nothing"):
+    repliesOf(1.hour)(conn =>
+      conn.receive(slowQuery("1")) *> IO.sleep(1.hour) *> conn.receive(complete("1"))
+    ).map: obt =>
+      assertEquals(obt.count(isNext("1")), 1, s"expected one result, got $obt")
+      assertEquals(countComplete("1")(obt), 1, s"expected one complete for id 1, got $obt")
+      assert(!obt.exists(isError("1")), s"the late complete produced an error, got $obt")
+      assert(!obt.exists(_.isTerminal), s"the late complete closed the socket, got $obt")
+
+  test("a client complete for an id that was never used is ignored"):
+    replies(complete("99")).map: obt =>
+      assertEquals(countComplete("99")(obt), 0, s"expected no complete for id 99, got $obt")
+      assert(!obt.exists(isError("99")), s"the unknown id produced an error, got $obt")
+      assert(!obt.exists(_.isTerminal), s"the unknown id closed the socket, got $obt")
+
+  test("a second subscribe that reuses the id of a running query closes the socket with 4409"):
+    replies(slowQuery("1"), slowQuery("1")).map: obt =>
+      val close = Reply.CloseWith(GraphQLWSError.SubscriberAlreadyExists("1"))
+      assert(obt.contains(close), s"expected a 4409 close request, got $obt")

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionCompleteSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionCompleteSuite.scala
@@ -18,9 +18,9 @@ import scala.concurrent.duration.*
 class SubscriptionCompleteSuite extends BaseSuite:
 
   def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
-    GraphQLService(VariablesMapping).some.pure[IO]
+    GraphQLService(TestMapping).some.pure[IO]
 
-  // VariablesMapping's Subscription.echo emits exactly 3 results and then ends.
+  // TestMapping's Subscription.echo emits exactly 3 results and then ends.
   private val echoQuery: String    = """subscription($abc: String) { echo(s: $abc) }"""
   private val echoVars: JsonObject = Json.obj("abc" -> Json.fromString("foo")).asObject.get
   private val expected: List[Json] = List.fill(3)(json"""{ "echo": "foo" }""")

--- a/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/SubscriptionsSuite.scala
@@ -149,7 +149,7 @@ class SubscriptionsSuite extends CatsEffectSuite:
         obt <- log
       yield assertEquals(obt, List("error:1"))
 
-  test("remove on a running subscription produces exactly one Complete"):
+  test("remove on a running subscription sends no Complete"):
     run: (subs, log) =>
       for
         _   <- subs.add("1", Stream.awakeEvery[IO](25.milliseconds).as(ok))
@@ -159,7 +159,7 @@ class SubscriptionsSuite extends CatsEffectSuite:
         obt <- log
       yield
         assert(obt.count(_ === "next:1") >= 1, "the stream sent nothing before remove")
-        assertEquals(obt.count(_ === "complete:1"), 1)
+        assertEquals(obt.count(_ === "complete:1"), 0)
 
   test("a subscribe with an id that is active reports a duplicate and sends nothing"):
     run: (subs, log) =>

--- a/modules/core/src/test/scala/lucuma/graphql/routes/TestMapping.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/TestMapping.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.*
+import fs2.Stream
+import grackle.Query.Binding
+import grackle.QueryCompiler.Elab
+import grackle.QueryCompiler.SelectElaborator
+import grackle.Result
+import grackle.Value.StringValue
+import grackle.circe.CirceMapping
+import grackle.syntax.*
+import io.circe.Json
+
+import scala.concurrent.duration.*
+
+// The GraphQL schema and mapping that the test suites share.
+
+object TestMapping extends CirceMapping[IO]:
+  val schema = schema"""
+    type Query {
+      echo(s: String): String!
+      slow: String!
+    }
+    type Mutation {
+      slowUpdate: String!
+    }
+    type Subscription {
+      echo(s: String): String!
+      empty: String!
+      ticks: String!
+    }
+  """
+  val QueryType        = schema.ref("Query")
+  val MutationType     = schema.ref("Mutation")
+  val SubscriptionType = schema.ref("Subscription")
+  // A single result that arrives after 10 seconds, so a test can act while it runs.
+  private val slowResult: IO[Result[Json]] =
+    IO.sleep(10.seconds).as(Result(Json.fromString("done")))
+  val typeMappings     = TypeMappings.unchecked(
+    ObjectMapping(QueryType, List(
+      CursorFieldJson("echo", c => c.envR[String]("s").map(Json.fromString), Nil),
+      RootEffect.computeJson("slow")((_, _) => slowResult)
+    )),
+    ObjectMapping(MutationType, List(
+      RootEffect.computeJson("slowUpdate")((_, _) => slowResult)
+    )),
+    ObjectMapping(SubscriptionType, List(
+      RootStream.computeJson("echo"): (_, e) =>
+        val r = e.getR[String]("s").map(Json.fromString)
+        Stream(r, r, r).covary[IO],
+      RootStream.computeJson("empty"): (_, _) =>
+        Stream.empty.covary[IO],
+      // A source stream that never ends, so a test can close the subscription while it runs.
+      RootStream.computeJson("ticks"): (_, _) =>
+        Stream.awakeEvery[IO](25.milliseconds).as(Result(Json.fromString("tick")))
+    ))
+  )
+  override val selectElaborator = SelectElaborator:
+    case (_, "echo", List(Binding("s", StringValue(s)))) => Elab.env("s" -> s)

--- a/modules/core/src/test/scala/lucuma/graphql/routes/VariablesSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/VariablesSuite.scala
@@ -5,60 +5,18 @@ package lucuma.graphql.routes
 
 import cats.effect.*
 import cats.implicits.*
-import fs2.Stream
-import grackle.Query.Binding
-import grackle.QueryCompiler.Elab
-import grackle.QueryCompiler.SelectElaborator
-import grackle.Result
-import grackle.Schema
-import grackle.Value.StringValue
-import grackle.circe.CirceMapping
-import grackle.syntax.*
 import io.circe.Json
 import io.circe.literal.*
 import org.http4s.headers.Authorization
-
-import scala.concurrent.duration.*
 
 import BaseSuite.ClientOption
 import BaseSuite.ClientOption.*
 
 // This suite tests that variables make it through.
 
-object VariablesMapping extends CirceMapping[IO]:
-  val schema = schema"""
-    type Query {
-      echo(s: String): String!
-    }
-    type Subscription {
-      echo(s: String): String!
-      empty: String!
-      ticks: String!
-    }
-  """
-  val QueryType        = schema.ref("Query")
-  val SubscriptionType = schema.ref("Subscription")
-  val typeMappings     = TypeMappings.unchecked(
-    ObjectMapping(QueryType, List(
-      CursorFieldJson("echo", c => c.envR[String]("s").map(Json.fromString), Nil)
-    )),
-    ObjectMapping(SubscriptionType, List(
-      RootStream.computeJson("echo"): (_, e) =>
-        val r = e.getR[String]("s").map(Json.fromString)
-        Stream(r, r, r).covary[IO],
-      RootStream.computeJson("empty"): (_, _) =>
-        Stream.empty.covary[IO],
-      // A source stream that never ends, so a test can close the subscription while it runs.
-      RootStream.computeJson("ticks"): (_, _) =>
-        Stream.awakeEvery[IO](25.milliseconds).as(Result(Json.fromString("tick")))
-    ))
-  )
-  override val selectElaborator = SelectElaborator:
-    case (_, "echo", List(Binding("s", StringValue(s)))) => Elab.env("s" -> s)
-
 class VariablesSuite extends BaseSuite:
   def service(auth: Option[Authorization]): IO[Option[GraphQLService[IO]]] =
-    GraphQLService(VariablesMapping).some.pure[IO]
+    GraphQLService(TestMapping).some.pure[IO]
 
   def testQuery(option: ClientOption): IO[Unit] =
     expect(


### PR DESCRIPTION
Before, a query or mutation ran inline in the WebSocket receive loop. A slow operation blocked every other message on the connection, and the client had no way to stop it.

Now every operation runs as an event stream in the operation map. A subscription is its own stream. A query or mutation is a one-element stream. The receive loop stays free, and a client `complete` message cancels any operation.

Tests move the shared schema into TestMapping and add ConnectionSuite and
OperationCancelSuite.
