### PR TITLE
Close connection when `connection_init` does not arrive in time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val core = project
       ProblemFilters.exclude[DirectMissingMethodProblem]("lucuma.graphql.routes.Subscriptions.*"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("lucuma.graphql.routes.Subscriptions#Subscription.*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("lucuma.graphql.routes.Subscriptions#Subscription.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("lucuma.graphql.routes.Connection#ConnectionState.*"),
       ProblemFilters.exclude[MissingClassProblem]("lucuma.graphql.routes.package"),
       ProblemFilters.exclude[MissingClassProblem]("lucuma.graphql.routes.package$")
     ),

--- a/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/Connection.scala
@@ -5,11 +5,13 @@ package lucuma.graphql.routes
 
 import cats.MonadError
 import cats.MonadThrow
-import cats.effect.Concurrent
+import cats.effect.Deferred
 import cats.effect.Ref
 import cats.effect.Resource
+import cats.effect.Temporal
 import cats.effect.std.Queue
 import cats.effect.std.Supervisor
+import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import clue.model.GraphQLRequest
 import clue.model.StreamingMessage.*
@@ -27,6 +29,8 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.syntax.*
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.Tracer
+
+import scala.concurrent.duration.*
 
 /** A web-socket connection that receives messages from a client and processes them. */
 sealed trait Connection[F[_]] {
@@ -47,7 +51,7 @@ object Connection {
 
   /**
    * Connection is a state machine that (typically) transitions from states `PendingInit` to
-   * `Connected` to `Terminated` as it receives messages from the client.
+   * `Connected` to `Closed` as it receives messages from the client.
    */
   sealed trait ConnectionState[F[_]] {
 
@@ -81,6 +85,12 @@ object Connection {
      * @return state transition and action
      */
     def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit])
+
+    /**
+     * Handles the expiry of the wait time for `connection_init`.
+     * @return state transition and action to execute
+     */
+    def initTimedOut: (ConnectionState[F], F[Unit])
 
   }
 
@@ -119,6 +129,9 @@ object Connection {
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
         (closed, replyQueue.offer(lastReply(reason)))
+
+      override def initTimedOut: (ConnectionState[F], F[Unit]) =
+        close(GraphQLWSError.InitializationTimeout.some)
 
     }
 
@@ -184,6 +197,10 @@ object Connection {
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
         (closed, subscriptions.removeAll *> send(lastReply(reason)))
+
+      // `connection_init` arrived in time, so the expiry of the timer means nothing here.
+      override def initTimedOut: (ConnectionState[F], F[Unit]) =
+        (this, ().pure[F])
     }
 
   /**
@@ -214,26 +231,38 @@ object Connection {
 
       override def close(reason: Option[GraphQLWSError]): (ConnectionState[F], F[Unit]) =
         (this, M.unit)
+
+      override def initTimedOut: (ConnectionState[F], F[Unit]) =
+        ignore("connection_init timeout")(())
     }
 
-  def apply[F[_]: {Concurrent, Logger, Tracer as T}](
+  /** The wait time for `connection_init`. The protocol reserves close code 4408 for its expiry. */
+  val ConnectionInitWaitTimeout: FiniteDuration = 10.seconds
+
+  def apply[F[_]: {Temporal, Logger, Tracer as T}](
     service: Option[Authorization] => F[Option[GraphQLService[F]]],
     replyQueue: Queue[F, Reply]
   ): Resource[F, Connection[F]] =
     Supervisor[F].flatMap(supervisor => Resource.make(build(service, replyQueue, supervisor))(_.close))
 
-  private def build[F[_]: {Concurrent, Logger, Tracer as T}](
+  private def build[F[_]: {Temporal, Logger, Tracer as T}](
     service: Option[Authorization] => F[Option[GraphQLService[F]]],
     replyQueue: Queue[F, Reply],
     supervisor: Supervisor[F]
   ): F[Connection[F]] =
 
-    Ref.of(pendingInit[F](replyQueue)).map { stateRef =>
+    (Ref.of(pendingInit[F](replyQueue)), Deferred[F, Unit]).flatMapN { (stateRef, initReceived) =>
 
-      new Connection[F] {
+      def handle[A](f: ConnectionState[F] => (ConnectionState[F], F[A])): F[A] =
+        stateRef.modify(f).flatten
 
-        def handle[A](f: ConnectionState[F] => (ConnectionState[F], F[A])): F[A] =
-          stateRef.modify(f).flatten
+      /**
+       * The timer for the `connection_init` message. If it expires, the connection is closed with code 4408. If the message arrives in time, the timer does nothing.
+       */
+      val initTimer: F[Unit] =
+        initReceived.get.timeoutTo(ConnectionInitWaitTimeout, handle(_.initTimedOut))
+
+      val connection = new Connection[F] {
 
         // The one way to send a reply to the client. It offers the reply to the queue and logs it.
         val reply: Reply => F[Unit] = { m =>
@@ -296,7 +325,7 @@ object Connection {
         override def receive(m: FromClient): F[Unit] =
           debug"received $m" *> {
             m match {
-              case ConnectionInit(m)       => init(m)
+              case ConnectionInit(m)       => initReceived.complete(()).void *> init(m)
               case Subscribe(id, request)  => handle(_.start(id, request)).flatMap(_.traverse_(e => handle(_.close(e.some))))
               case FromClient.Complete(id) => handle(_.stop(id))
               case FromClient.Ping(_)      => reply(Reply.Send(FromServer.Pong()))
@@ -307,5 +336,7 @@ object Connection {
         override def close: F[Unit] =
           handle(_.close(none))
       }
+
+      supervisor.supervise(initTimer).as(connection)
     }
 }

--- a/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLWSError.scala
+++ b/modules/core/src/main/scala/lucuma/graphql/routes/GraphQLWSError.scala
@@ -7,6 +7,6 @@ enum GraphQLWSError(val code: Int, val reason: String):
   case InvalidMessage(message: String) extends GraphQLWSError(4400, s"Invalid message received: $message")// TODO Not implemented yet 
   case Unauthorized(request: String) extends GraphQLWSError(4401, s"Unauthorized. Request '$request' received on un-initialized connection.")
   case Forbidden(msg: String) extends GraphQLWSError(4403, s"Forbidden: $msg")
-  case InitializationTimeout extends GraphQLWSError(4408, "Connection initialization timeout") // TODO Not implemented yet 
+  case InitializationTimeout extends GraphQLWSError(4408, "Connection initialization timeout")
   case SubscriberAlreadyExists(id: String) extends GraphQLWSError(4409, s"Subscriber with id '$id' already exists")
   case TooManyInitializationRequests extends GraphQLWSError(4429, "Too many initialization requests") // TODO Not implemented yet 

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionInitTimeoutSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionInitTimeoutSuite.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.graphql.routes
+
+import cats.effect.IO
+import cats.syntax.all.*
+import clue.model.StreamingMessage.FromServer
+
+import scala.concurrent.duration.*
+
+/**
+ * The graphql-transport-ws protocol reserves close code 4408 for a connection that sends no
+ * `connection_init` message before the wait time passes. This suite runs the connection on the
+ * virtual clock and reads the replies straight off the queue.
+ */
+final class ConnectionInitTimeoutSuite extends ConnectionSuite:
+
+  private val timeoutClose: Reply =
+    Reply.CloseWith(GraphQLWSError.InitializationTimeout)
+
+  private val ack: Reply =
+    Reply.Send(FromServer.ConnectionAck())
+
+  private val beforeExpiry: FiniteDuration = Connection.ConnectionInitWaitTimeout - 1.second
+  private val afterExpiry: FiniteDuration  = Connection.ConnectionInitWaitTimeout + 1.second
+
+  test("no connection_init before the timeout closes the socket with code 4408"):
+    rawRepliesOf(afterExpiry)(_ => IO.unit).map: obt =>
+      assertEquals(obt.lastOption, timeoutClose.some, s"expected a 4408 close request, got $obt")
+
+  test("the timeout close does not arrive before the wait time passes"):
+    rawRepliesOf(beforeExpiry)(_ => IO.unit).map: obt =>
+      assert(!obt.contains(timeoutClose), s"the timer fired early, got $obt")
+
+  test("a timely connection_init prevents the 4408 close"):
+    rawRepliesOf(afterExpiry)(_.receive(init)).map: obt =>
+      assert(!obt.contains(timeoutClose), s"the timer fired after connection_init, got $obt")
+
+  test("a connection_init that arrives after the timeout is ignored"):
+    rawRepliesOf(1.second): conn =>
+      IO.sleep(afterExpiry) *> conn.receive(init)
+    .map: obt =>
+      assert(!obt.contains(ack), s"a late connection_init was acknowledged, got $obt")
+
+  test("slow authorization after a timely connection_init does not cause a 4408 close"):
+    val slow = IO.sleep(Connection.ConnectionInitWaitTimeout * 2) *> testService
+    rawRepliesOf(Connection.ConnectionInitWaitTimeout * 3, slow)(_.receive(init)).map: obt =>
+      assert(!obt.contains(timeoutClose), s"slow authorization was reported as a 4408, got $obt")
+      assert(obt.contains(ack), s"the connection was not acknowledged, got $obt")
+
+  test("a close from the client prevents a later 4408 close"):
+    rawRepliesOf(afterExpiry)(_.close).map: obt =>
+      assert(!obt.contains(timeoutClose), s"the timer fired after close, got $obt")

--- a/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionSuite.scala
+++ b/modules/core/src/test/scala/lucuma/graphql/routes/ConnectionSuite.scala
@@ -34,20 +34,32 @@ abstract class ConnectionSuite extends CatsEffectSuite:
 
   protected def complete(id: String): FromClient = FromClient.Complete(id)
 
+  /** The service that the connection authorizes against. */
+  protected val testService: IO[Option[GraphQLService[IO]]] =
+    GraphQLService(TestMapping).some.pure[IO]
+
+  // Runs the script against a connection that received no `connection_init` message, then returns
+  // every reply that the connection made, after the given settle time. Use this to test the
+  // handshake itself. For everything else, use `repliesOf`.
+  protected def rawRepliesOf(
+    settle:  FiniteDuration,
+    service: IO[Option[GraphQLService[IO]]] = testService
+  )(script: Connection[IO] => IO[Unit]): IO[List[Reply]] =
+    TestControl.executeEmbed:
+      BaseSuite
+        .connectionResource(_ => service)
+        .use: (conn, queue) =>
+          script(conn) *>
+            IO.sleep(settle) *>
+            queue.tryTakeN(none)
+
   // Runs the script against an initialized connection on the virtual clock, then returns every
   // reply that the connection made, after the given settle time. A script can sleep between
   // messages, so a test can put a client message after the result of an operation.
   protected def repliesOf(
     settle: FiniteDuration
   )(script: Connection[IO] => IO[Unit]): IO[List[Reply]] =
-    TestControl.executeEmbed:
-      BaseSuite
-        .connectionResource(_ => GraphQLService(TestMapping).some.pure[IO])
-        .use: (conn, queue) =>
-          conn.receive(init) *>
-            script(conn) *>
-            IO.sleep(settle) *>
-            queue.tryTakeN(none)
+    rawRepliesOf(settle)(conn => conn.receive(init) *> script(conn))
 
   // Sends the messages to an initialized connection on the virtual clock, then returns every
   // reply that the connection made, after the given settle time.


### PR DESCRIPTION
The server waited without a limit for the connection_init message, so an idle socket stayed open and held resources. The connection now supervises a timer for the connection_init message. If the message does not arrive before the timeout, the socket closes with code 4408.

The timer waits on the message itself, not on the authorization that follows it, so slow authorization does not cause a false 4408. After initialization or after a close, the state machine ignores the expiry.

The connection state machine gets a new method for this transition. A MiMa filter covers the change, because the trait is sealed and no caller can implement it.

Protocol: https://github.com/enisdenjo/graphql-ws/blob/839ca7d652004513a063dd44e9bcfe7a3301f6f0/PROTOCOL.md#connectioninit
